### PR TITLE
Allow omitting of error data value as specified in JSON-RPC 2.0

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -64,7 +64,8 @@ class Response
         // re-produce error state
         if (isset($options['error']) && is_array($options['error'])) {
             $error = $options['error'];
-            $options['error'] = new Error($error['message'], $error['code'], $error['data']);
+            $errorData = isset($error['data']) ? $error['data'] : null;
+            $options['error'] = new Error($error['message'], $error['code'], $errorData);
         }
 
         $methods = get_class_methods($this);

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class ResponseTest extends TestCase
 {
+    private $response;
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
@@ -211,5 +212,23 @@ class ResponseTest extends TestCase
             0 => '2.0',
         ]);
         $this->assertNull($this->response->getVersion());
+    }
+
+    /**
+     * Assert that error data can be omitted
+     * @see https://www.jsonrpc.org/specification#response_object
+     */
+    public function testSetOptionsAcceptsErrorWithEmptyDate()
+    {
+        $this->response->setOptions([
+            'error' => [
+                'code' => 0,
+                'message' => 'Lorem Ipsum',
+            ],
+        ]);
+        $this->assertInstanceOf(Error::class, $this->response->getError());
+        $this->assertEquals(-32000, $this->response->getError()->getCode());
+        $this->assertEquals('Lorem Ipsum', $this->response->getError()->getMessage());
+        $this->assertEquals(null, $this->response->getError()->getData());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR allows omitting the `data` value of an `error` object as specified in [JSON-RPC 2.0](https://www.jsonrpc.org/specification#response_object)

>data
A Primitive or Structured value that contains additional information about the error.
**This may be omitted.**
The value of this member is defined by the Server (e.g. detailed error information, nested errors etc.).

#### How do you reproduce it?

```php
$response = new Laminas\Json\Server\Response();
$response->setOptions([
    'error' => [
        'code' => 0,
        'message' => 'Lorem Ipsum',
    ],
]);
```

#### What did you expect to happen?

That the `error` object (array) is parsed correctly although `data` is omitted.

#### What actually happened?

`setOptions()` fails with an error.

```
Notice: Undefined index: data in vendor/laminas/laminas-json-server/src/Response.php on line 67
```