### PR TITLE
QA: Bump PHP version to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,36 +12,24 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.2
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.3
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.3
+    - php: 7.4
       env:
         - DEPS=latest
     - php: 7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#3](https://github.com/laminas/laminas-json-server/pull/3) Drops support for PHP 7.1 and below
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "laminas/laminas-http": "^2.7",
         "laminas/laminas-json": "^2.6.1 || ^3.0",
         "laminas/laminas-server": "^2.7",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR provides an PHP version update to 7.2 as described in #2 .

- Bump required PHP version in `composer.json` to `^7.2`
- Add PHP 7.4 support in Travis CI configuration
- Drop no longer maintained PHP versions in Travis CI configuration

