### PR TITLE
QA: strict types

### DIFF
--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -10,50 +10,22 @@ call the class `Calculator`, and define methods for `add`, `subtract`,
  */
 class Calculator
 {
-    /**
-     * Return sum of two variables
-     *
-     * @param  int $x
-     * @param  int $y
-     * @return int
-     */
-    public function add($x, $y)
+    public function add(int $x, int $y): int
     {
         return $x + $y;
     }
 
-    /**
-     * Return difference of two variables
-     *
-     * @param  int $x
-     * @param  int $y
-     * @return int
-     */
-    public function subtract($x, $y)
+    public function subtract(int $x, int $y): int
     {
         return $x - $y;
     }
 
-    /**
-     * Return product of two variables
-     *
-     * @param  int $x
-     * @param  int $y
-     * @return int
-     */
-    public function multiply($x, $y)
+    public function multiply(int $x, int $y): int
     {
         return $x * $y;
     }
 
-    /**
-     * Return the division of two variables
-     *
-     * @param  int $x
-     * @param  int $y
-     * @return float
-     */
-    public function divide($x, $y)
+    public function divide(int $x, int $y): float
     {
         return $x / $y;
     }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -12,6 +12,19 @@ namespace Laminas\Json\Server;
 
 use Laminas\Server\Cache as ServerCache;
 
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function is_readable;
+use function is_string;
+use function is_writable;
+use function restore_error_handler;
+use function set_error_handler;
+use function unlink;
+
+use const E_WARNING;
+
 /**
  * Cache server definition and SMD.
  */

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -38,7 +38,7 @@ class Cache extends ServerCache
      * @param  Server $server
      * @return bool
      */
-    public static function saveSmd(string $filename, Server $server) : bool
+    public static function saveSmd(string $filename, Server $server): bool
     {
         if (! file_exists($filename)
             && ! is_writable(dirname($filename))
@@ -99,7 +99,7 @@ class Cache extends ServerCache
      * @param  string $filename
      * @return bool
      */
-    public static function deleteSmd(string $filename) : bool
+    public static function deleteSmd(string $filename): bool
     {
         if (file_exists($filename)) {
             unlink($filename);

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -17,7 +17,6 @@ use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
 use function is_readable;
-use function is_string;
 use function is_writable;
 use function restore_error_handler;
 use function set_error_handler;
@@ -39,10 +38,10 @@ class Cache extends ServerCache
      * @param  Server $server
      * @return bool
      */
-    public static function saveSmd($filename, Server $server) : bool
+    public static function saveSmd(string $filename, Server $server) : bool
     {
-        if (! is_string($filename)
-            || (! file_exists($filename) && ! is_writable(dirname($filename)))
+        if (! file_exists($filename)
+            && ! is_writable(dirname($filename))
         ) {
             return false;
         }
@@ -71,10 +70,9 @@ class Cache extends ServerCache
      * @param  string $filename
      * @return string|false
      */
-    public static function getSmd($filename)
+    public static function getSmd(string $filename)
     {
-        if (! is_string($filename)
-            || ! file_exists($filename)
+        if (! file_exists($filename)
             || ! is_readable($filename)
         ) {
             return false;
@@ -101,9 +99,9 @@ class Cache extends ServerCache
      * @param  string $filename
      * @return bool
      */
-    public static function deleteSmd($filename) : bool
+    public static function deleteSmd(string $filename) : bool
     {
-        if (is_string($filename) && file_exists($filename)) {
+        if (file_exists($filename)) {
             unlink($filename);
             return true;
         }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Server\Cache as ServerCache;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -39,7 +39,7 @@ class Cache extends ServerCache
      * @param  Server $server
      * @return bool
      */
-    public static function saveSmd($filename, Server $server)
+    public static function saveSmd($filename, Server $server) : bool
     {
         if (! is_string($filename)
             || (! file_exists($filename) && ! is_writable(dirname($filename)))
@@ -101,7 +101,7 @@ class Cache extends ServerCache
      * @param  string $filename
      * @return bool
      */
-    public static function deleteSmd($filename)
+    public static function deleteSmd($filename) : bool
     {
         if (is_string($filename) && file_exists($filename)) {
             unlink($filename);

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,7 +68,7 @@ class Client implements ServerClient
      * @param  HttpClient $httpClient New HTTP client to use.
      * @return Client Self instance.
      */
-    public function setHttpClient(HttpClient $httpClient)
+    public function setHttpClient(HttpClient $httpClient) : Client
     {
         $this->httpClient = $httpClient;
         return $this;
@@ -79,7 +79,7 @@ class Client implements ServerClient
      *
      * @return HttpClient HTTP client.
      */
-    public function getHttpClient()
+    public function getHttpClient() : HttpClient
     {
         return $this->httpClient;
     }
@@ -89,7 +89,7 @@ class Client implements ServerClient
      *
      * @return Request
      */
-    public function getLastRequest()
+    public function getLastRequest() : Request
     {
         return $this->lastRequest;
     }
@@ -99,7 +99,7 @@ class Client implements ServerClient
      *
      * @return Response
      */
-    public function getLastResponse()
+    public function getLastResponse() : Response
     {
         return $this->lastResponse;
     }
@@ -111,7 +111,7 @@ class Client implements ServerClient
      * @return Response Response.
      * @throws Exception\HttpException When HTTP communication fails.
      */
-    public function doRequest($request)
+    public function doRequest($request) : Response
     {
         $this->lastRequest = $request;
 
@@ -188,7 +188,7 @@ class Client implements ServerClient
      * @param  array $params List of arguments.
      * @return Request Created request.
      */
-    protected function createRequest($method, array $params)
+    protected function createRequest($method, array $params) : Request
     {
         $request = new Request();
         $request->setMethod($method)

--- a/src/Client.php
+++ b/src/Client.php
@@ -56,7 +56,7 @@ class Client implements ServerClient
      * @param string $server Full address of the JSON-RPC service.
      * @param HttpClient $httpClient HTTP Client to use for requests.
      */
-    public function __construct($server, HttpClient $httpClient = null)
+    public function __construct(string $server, HttpClient $httpClient = null)
     {
         $this->httpClient = $httpClient ?: new HttpClient();
         $this->serverAddress = $server;
@@ -111,7 +111,7 @@ class Client implements ServerClient
      * @return Response Response.
      * @throws Exception\HttpException When HTTP communication fails.
      */
-    public function doRequest($request) : Response
+    public function doRequest(Request $request) : Response
     {
         $this->lastRequest = $request;
 
@@ -188,7 +188,7 @@ class Client implements ServerClient
      * @param  array $params List of arguments.
      * @return Request Created request.
      */
-    protected function createRequest($method, array $params) : Request
+    protected function createRequest(string $method, array $params) : Request
     {
         $request = new Request();
         $request->setMethod($method)

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,7 +68,7 @@ class Client implements ServerClient
      * @param  HttpClient $httpClient New HTTP client to use.
      * @return Client Self instance.
      */
-    public function setHttpClient(HttpClient $httpClient) : Client
+    public function setHttpClient(HttpClient $httpClient): Client
     {
         $this->httpClient = $httpClient;
         return $this;
@@ -79,7 +79,7 @@ class Client implements ServerClient
      *
      * @return HttpClient HTTP client.
      */
-    public function getHttpClient() : HttpClient
+    public function getHttpClient(): HttpClient
     {
         return $this->httpClient;
     }
@@ -89,7 +89,7 @@ class Client implements ServerClient
      *
      * @return Request
      */
-    public function getLastRequest() : ?Request
+    public function getLastRequest(): ?Request
     {
         return $this->lastRequest;
     }
@@ -99,7 +99,7 @@ class Client implements ServerClient
      *
      * @return Response
      */
-    public function getLastResponse() : ?Response
+    public function getLastResponse(): ?Response
     {
         return $this->lastResponse;
     }
@@ -111,7 +111,7 @@ class Client implements ServerClient
      * @return Response Response.
      * @throws Exception\HttpException When HTTP communication fails.
      */
-    public function doRequest(Request $request) : Response
+    public function doRequest(Request $request): Response
     {
         $this->lastRequest = $request;
 
@@ -188,7 +188,7 @@ class Client implements ServerClient
      * @param  array $params List of arguments.
      * @return Request Created request.
      */
-    protected function createRequest(string $method, array $params) : Request
+    protected function createRequest(string $method, array $params): Request
     {
         $request = new Request();
         $request->setMethod($method)

--- a/src/Client.php
+++ b/src/Client.php
@@ -89,7 +89,7 @@ class Client implements ServerClient
      *
      * @return Request
      */
-    public function getLastRequest() : Request
+    public function getLastRequest() : ?Request
     {
         return $this->lastRequest;
     }
@@ -99,7 +99,7 @@ class Client implements ServerClient
      *
      * @return Response
      */
-    public function getLastResponse() : Response
+    public function getLastResponse() : ?Response
     {
         return $this->lastResponse;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Http\Client as HttpClient;

--- a/src/Error.php
+++ b/src/Error.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Json\Json;

--- a/src/Error.php
+++ b/src/Error.php
@@ -40,14 +40,14 @@ class Error
      *
      * @var string
      */
-    protected $message;
+    protected $message = '';
 
     /**
      * @param  string $message
      * @param  int $code
      * @param  mixed $data
      */
-    public function __construct(?string $message = null, int $code = self::ERROR_OTHER, $data = null)
+    public function __construct(?string $message = '', int $code = self::ERROR_OTHER, $data = null)
     {
         $this->setMessage($message)
              ->setCode($code)

--- a/src/Error.php
+++ b/src/Error.php
@@ -12,12 +12,6 @@ namespace Laminas\Json\Server;
 
 use Laminas\Json\Json;
 
-use function is_bool;
-use function is_float;
-use function is_numeric;
-use function is_scalar;
-use function is_string;
-
 class Error
 {
     const ERROR_PARSE           = -32700;
@@ -53,7 +47,7 @@ class Error
      * @param  int $code
      * @param  mixed $data
      */
-    public function __construct($message = null, $code = self::ERROR_OTHER, $data = null)
+    public function __construct(?string $message = null, int $code = self::ERROR_OTHER, $data = null)
     {
         $this->setMessage($message)
              ->setCode($code)
@@ -68,18 +62,8 @@ class Error
      * @param  int $code
      * @return self
      */
-    public function setCode($code) : self
+    public function setCode(int $code) : self
     {
-        if (! is_scalar($code) || is_bool($code) || is_float($code)) {
-            return $this;
-        }
-
-        if (is_string($code) && ! is_numeric($code)) {
-            return $this;
-        }
-
-        $code = (int) $code;
-
         if (0 === $code) {
             $this->code = self::ERROR_OTHER;
             return $this;
@@ -92,9 +76,9 @@ class Error
     /**
      * Get error code
      *
-     * @return int|null
+     * @return int
      */
-    public function getCode() : ?int
+    public function getCode() : int
     {
         return $this->code;
     }
@@ -105,13 +89,9 @@ class Error
      * @param  string $message
      * @return self
      */
-    public function setMessage($message) : self
+    public function setMessage(string $message) : self
     {
-        if (! is_scalar($message)) {
-            return $this;
-        }
-
-        $this->message = (string) $message;
+        $this->message = $message;
         return $this;
     }
 

--- a/src/Error.php
+++ b/src/Error.php
@@ -68,7 +68,7 @@ class Error
      * @param  int $code
      * @return self
      */
-    public function setCode($code)
+    public function setCode($code) : self
     {
         if (! is_scalar($code) || is_bool($code) || is_float($code)) {
             return $this;
@@ -94,7 +94,7 @@ class Error
      *
      * @return int|null
      */
-    public function getCode()
+    public function getCode() : ?int
     {
         return $this->code;
     }
@@ -105,7 +105,7 @@ class Error
      * @param  string $message
      * @return self
      */
-    public function setMessage($message)
+    public function setMessage($message) : self
     {
         if (! is_scalar($message)) {
             return $this;
@@ -120,7 +120,7 @@ class Error
      *
      * @return string
      */
-    public function getMessage()
+    public function getMessage() : string
     {
         return $this->message;
     }
@@ -131,7 +131,7 @@ class Error
      * @param  mixed $data
      * @return self
      */
-    public function setData($data)
+    public function setData($data) : self
     {
         $this->data = $data;
         return $this;
@@ -152,7 +152,7 @@ class Error
      *
      * @return array
      */
-    public function toArray()
+    public function toArray() : array
     {
         return [
             'code'    => $this->getCode(),
@@ -166,7 +166,7 @@ class Error
      *
      * @return string
      */
-    public function toJson()
+    public function toJson() : string
     {
         return Json::encode($this->toArray());
     }
@@ -176,7 +176,7 @@ class Error
      *
      * @return string
      */
-    public function __toString()
+    public function __toString() : string
     {
         return $this->toJson();
     }

--- a/src/Error.php
+++ b/src/Error.php
@@ -47,7 +47,7 @@ class Error
      * @param  int $code
      * @param  mixed $data
      */
-    public function __construct(?string $message = '', int $code = self::ERROR_OTHER, $data = null)
+    public function __construct(string $message = '', int $code = self::ERROR_OTHER, $data = null)
     {
         $this->setMessage($message)
              ->setCode($code)

--- a/src/Error.php
+++ b/src/Error.php
@@ -62,7 +62,7 @@ class Error
      * @param  int $code
      * @return self
      */
-    public function setCode(int $code) : self
+    public function setCode(int $code): self
     {
         if (0 === $code) {
             $this->code = self::ERROR_OTHER;
@@ -78,7 +78,7 @@ class Error
      *
      * @return int
      */
-    public function getCode() : int
+    public function getCode(): int
     {
         return $this->code;
     }
@@ -89,7 +89,7 @@ class Error
      * @param  string $message
      * @return self
      */
-    public function setMessage(string $message) : self
+    public function setMessage(string $message): self
     {
         $this->message = $message;
         return $this;
@@ -100,7 +100,7 @@ class Error
      *
      * @return string
      */
-    public function getMessage() : string
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -111,7 +111,7 @@ class Error
      * @param  mixed $data
      * @return self
      */
-    public function setData($data) : self
+    public function setData($data): self
     {
         $this->data = $data;
         return $this;
@@ -132,7 +132,7 @@ class Error
      *
      * @return array
      */
-    public function toArray() : array
+    public function toArray(): array
     {
         return [
             'code'    => $this->getCode(),
@@ -146,7 +146,7 @@ class Error
      *
      * @return string
      */
-    public function toJson() : string
+    public function toJson(): string
     {
         return Json::encode($this->toArray());
     }
@@ -156,7 +156,7 @@ class Error
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->toJson();
     }

--- a/src/Error.php
+++ b/src/Error.php
@@ -12,6 +12,12 @@ namespace Laminas\Json\Server;
 
 use Laminas\Json\Json;
 
+use function is_bool;
+use function is_float;
+use function is_numeric;
+use function is_scalar;
+use function is_string;
+
 class Error
 {
     const ERROR_PARSE           = -32700;

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface

--- a/src/Exception/ErrorException.php
+++ b/src/Exception/ErrorException.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 /**

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 interface ExceptionInterface

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 /**

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 class RuntimeException extends \RuntimeException implements ExceptionInterface

--- a/src/Request.php
+++ b/src/Request.php
@@ -257,7 +257,7 @@ class Request
      */
     public function setVersion(string $version): self
     {
-        if ('2.0' == $version) {
+        if ('2.0' === $version) {
             $this->version = '2.0';
             return $this;
         }

--- a/src/Request.php
+++ b/src/Request.php
@@ -137,7 +137,7 @@ class Request
      * Overwrite params.
      *
      * @param  array $params
-     * @return \Laminas\Json\Server\Request
+     * @return Request
      */
     public function setParams(array $params) : Request
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Exception;

--- a/src/Request.php
+++ b/src/Request.php
@@ -17,7 +17,6 @@ use function array_key_exists;
 use function count;
 use function get_class_methods;
 use function in_array;
-use function is_string;
 use function preg_match;
 use function ucfirst;
 
@@ -107,9 +106,9 @@ class Request
      * @param  string $key
      * @return self
      */
-    public function addParam($value, $key = null) : self
+    public function addParam($value, ?string $key = null) : self
     {
-        if ((null === $key) || ! is_string($key)) {
+        if (null === $key) {
             $index = count($this->params);
             $this->params[$index] = $value;
             return $this;
@@ -176,7 +175,7 @@ class Request
      * @param  string $name
      * @return self
      */
-    public function setMethod($name) : self
+    public function setMethod(string $name) : self
     {
         if (! preg_match($this->methodRegex, $name)) {
             $this->isMethodError = true;
@@ -245,7 +244,7 @@ class Request
      * @param  string $version
      * @return self
      */
-    public function setVersion($version) : self
+    public function setVersion(string $version) : self
     {
         if ('2.0' == $version) {
             $this->version = '2.0';
@@ -272,7 +271,7 @@ class Request
      * @param  string $json
      * @return void
      */
-    public function loadJson($json) : void
+    public function loadJson(string $json) : void
     {
         try {
             $options = Json::decode($json, Json::TYPE_ARRAY);

--- a/src/Request.php
+++ b/src/Request.php
@@ -102,7 +102,7 @@ class Request
                 continue;
             }
 
-            if ($key == 'jsonrpc') {
+            if ($key === 'jsonrpc') {
                 $this->setVersion($value);
                 continue;
             }
@@ -312,7 +312,7 @@ class Request
             $jsonArray['params'] = $params;
         }
 
-        if ('2.0' == $this->getVersion()) {
+        if ('2.0' === $this->getVersion()) {
             $jsonArray['jsonrpc'] = '2.0';
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -27,7 +27,18 @@ use function ucfirst;
 class Request
 {
     /**
-     * Request ID
+     * Request id
+     *
+     * JSON-RPC 1.0
+     * The request id. This can be of any type. It is used to match the response with the request that it is replying
+     * to.
+     * @see https://www.jsonrpc.org/specification_v1#a1.1Requestmethodinvocation
+     *
+     * JSON-RPC 2.0 allows any type
+     * An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is
+     * not included it is assumed to be a notification. The value SHOULD normally not be Null and Numbers SHOULD NOT
+     * contain fractional parts
+     * @see https://www.jsonrpc.org/specification#request_object
      *
      * @var mixed
      */
@@ -52,7 +63,7 @@ class Request
      *
      * @var string
      */
-    protected $method;
+    protected $method = '';
 
     /**
      * Regex for method.
@@ -106,9 +117,9 @@ class Request
      * @param  string $key
      * @return self
      */
-    public function addParam($value, ?string $key = null) : self
+    public function addParam($value,  $key = null) : self
     {
-        if (null === $key) {
+        if ((null === $key) || ! is_string($key)) {
             $index = count($this->params);
             $this->params[$index] = $value;
             return $this;
@@ -224,16 +235,16 @@ class Request
      */
     public function setId($name) : self
     {
-        $this->id = (string) $name;
+        $this->id = $name;
         return $this;
     }
 
     /**
      * Retrieve request identifier.
      *
-     * @return string
+     * @return mixed
      */
-    public function getId() : string
+    public function getId()
     {
         return $this->id;
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -13,6 +13,14 @@ namespace Laminas\Json\Server;
 use Exception;
 use Laminas\Json\Json;
 
+use function array_key_exists;
+use function count;
+use function get_class_methods;
+use function in_array;
+use function is_string;
+use function preg_match;
+use function ucfirst;
+
 /**
  * @todo Revised method regex to allow NS; however, should SMD be revised to
  *     strip PHP NS instead when attaching functions?

--- a/src/Request.php
+++ b/src/Request.php
@@ -82,7 +82,7 @@ class Request
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options) : self
     {
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
@@ -107,7 +107,7 @@ class Request
      * @param  string $key
      * @return self
      */
-    public function addParam($value, $key = null)
+    public function addParam($value, $key = null) : self
     {
         if ((null === $key) || ! is_string($key)) {
             $index = count($this->params);
@@ -125,7 +125,7 @@ class Request
      * @param  array $params
      * @return self
      */
-    public function addParams(array $params)
+    public function addParams(array $params) : self
     {
         foreach ($params as $key => $value) {
             $this->addParam($value, $key);
@@ -139,7 +139,7 @@ class Request
      * @param  array $params
      * @return \Laminas\Json\Server\Request
      */
-    public function setParams(array $params)
+    public function setParams(array $params) : Request
     {
         $this->params = [];
         return $this->addParams($params);
@@ -165,7 +165,7 @@ class Request
      *
      * @return array
      */
-    public function getParams()
+    public function getParams() : array
     {
         return $this->params;
     }
@@ -176,7 +176,7 @@ class Request
      * @param  string $name
      * @return self
      */
-    public function setMethod($name)
+    public function setMethod($name) : self
     {
         if (! preg_match($this->methodRegex, $name)) {
             $this->isMethodError = true;
@@ -192,7 +192,7 @@ class Request
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod() : string
     {
         return $this->method;
     }
@@ -202,7 +202,7 @@ class Request
      *
      * @return bool
      */
-    public function isMethodError()
+    public function isMethodError() : bool
     {
         return $this->isMethodError;
     }
@@ -212,7 +212,7 @@ class Request
      *
      * @return bool
      */
-    public function isParseError()
+    public function isParseError() : bool
     {
         return $this->isParseError;
     }
@@ -223,7 +223,7 @@ class Request
      * @param  mixed $name
      * @return self
      */
-    public function setId($name)
+    public function setId($name) : self
     {
         $this->id = (string) $name;
         return $this;
@@ -234,7 +234,7 @@ class Request
      *
      * @return string
      */
-    public function getId()
+    public function getId() : string
     {
         return $this->id;
     }
@@ -245,7 +245,7 @@ class Request
      * @param  string $version
      * @return self
      */
-    public function setVersion($version)
+    public function setVersion($version) : self
     {
         if ('2.0' == $version) {
             $this->version = '2.0';
@@ -261,7 +261,7 @@ class Request
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion() : string
     {
         return $this->version;
     }
@@ -272,7 +272,7 @@ class Request
      * @param  string $json
      * @return void
      */
-    public function loadJson($json)
+    public function loadJson($json) : void
     {
         try {
             $options = Json::decode($json, Json::TYPE_ARRAY);
@@ -287,7 +287,7 @@ class Request
      *
      * @return string
      */
-    public function toJson()
+    public function toJson() : string
     {
         $jsonArray = [
             'method' => $this->getMethod()
@@ -314,7 +314,7 @@ class Request
      *
      * @return string
      */
-    public function __toString()
+    public function __toString() : string
     {
         return $this->toJson();
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -92,7 +92,7 @@ class Request
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options) : self
+    public function setOptions(array $options): self
     {
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
@@ -117,7 +117,7 @@ class Request
      * @param  string $key
      * @return self
      */
-    public function addParam($value, $key = null) : self
+    public function addParam($value, $key = null): self
     {
         if ((null === $key) || ! is_string($key)) {
             $index = count($this->params);
@@ -135,7 +135,7 @@ class Request
      * @param  array $params
      * @return self
      */
-    public function addParams(array $params) : self
+    public function addParams(array $params): self
     {
         foreach ($params as $key => $value) {
             $this->addParam($value, $key);
@@ -149,7 +149,7 @@ class Request
      * @param  array $params
      * @return Request
      */
-    public function setParams(array $params) : Request
+    public function setParams(array $params): Request
     {
         $this->params = [];
         return $this->addParams($params);
@@ -175,7 +175,7 @@ class Request
      *
      * @return array
      */
-    public function getParams() : array
+    public function getParams(): array
     {
         return $this->params;
     }
@@ -186,7 +186,7 @@ class Request
      * @param  string $name
      * @return self
      */
-    public function setMethod(string $name) : self
+    public function setMethod(string $name): self
     {
         if (! preg_match($this->methodRegex, $name)) {
             $this->isMethodError = true;
@@ -202,7 +202,7 @@ class Request
      *
      * @return string
      */
-    public function getMethod() : string
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -212,7 +212,7 @@ class Request
      *
      * @return bool
      */
-    public function isMethodError() : bool
+    public function isMethodError(): bool
     {
         return $this->isMethodError;
     }
@@ -222,7 +222,7 @@ class Request
      *
      * @return bool
      */
-    public function isParseError() : bool
+    public function isParseError(): bool
     {
         return $this->isParseError;
     }
@@ -233,7 +233,7 @@ class Request
      * @param  mixed $name
      * @return self
      */
-    public function setId($name) : self
+    public function setId($name): self
     {
         $this->id = $name;
         return $this;
@@ -255,7 +255,7 @@ class Request
      * @param  string $version
      * @return self
      */
-    public function setVersion(string $version) : self
+    public function setVersion(string $version): self
     {
         if ('2.0' == $version) {
             $this->version = '2.0';
@@ -271,7 +271,7 @@ class Request
      *
      * @return string
      */
-    public function getVersion() : string
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -282,7 +282,7 @@ class Request
      * @param  string $json
      * @return void
      */
-    public function loadJson(string $json) : void
+    public function loadJson(string $json): void
     {
         try {
             $options = Json::decode($json, Json::TYPE_ARRAY);
@@ -297,7 +297,7 @@ class Request
      *
      * @return string
      */
-    public function toJson() : string
+    public function toJson(): string
     {
         $jsonArray = [
             'method' => $this->getMethod()
@@ -324,7 +324,7 @@ class Request
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->toJson();
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -117,7 +117,7 @@ class Request
      * @param  string $key
      * @return self
      */
-    public function addParam($value,  $key = null) : self
+    public function addParam($value, $key = null) : self
     {
         if ((null === $key) || ! is_string($key)) {
             $index = count($this->params);

--- a/src/Request.php
+++ b/src/Request.php
@@ -97,7 +97,7 @@ class Request
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
             $method = 'set' . ucfirst($key);
-            if (in_array($method, $methods)) {
+            if (in_array($method, $methods, true)) {
                 $this->$method($value);
                 continue;
             }

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Request;
 
 use Laminas\Json\Server\Request as JsonRequest;

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -12,6 +12,8 @@ namespace Laminas\Json\Server\Request;
 
 use Laminas\Json\Server\Request as JsonRequest;
 
+use function file_get_contents;
+
 class Http extends JsonRequest
 {
     /**

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -40,7 +40,7 @@ class Http extends JsonRequest
      *
      * @return string
      */
-    public function getRawJson()
+    public function getRawJson() : string
     {
         return $this->rawJson;
     }

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -40,7 +40,7 @@ class Http extends JsonRequest
      *
      * @return string
      */
-    public function getRawJson() : string
+    public function getRawJson(): string
     {
         return $this->rawJson;
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -151,7 +151,7 @@ class Response
      * @param  mixed $error
      * @return self
      */
-    public function setError(Error $error = null): self
+    public function setError(?Error $error = null): self
     {
         $this->error = $error;
         return $this;

--- a/src/Response.php
+++ b/src/Response.php
@@ -273,8 +273,8 @@ class Response
     /**
      * Set service map object.
      *
-     * @param  Smd $serviceMap
-     * @return self|null
+     * @param  Smd|null $serviceMap
+     * @return self
      */
     public function setServiceMap(?Smd $serviceMap): self
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -203,7 +203,7 @@ class Response
      * Set JSON-RPC version.
      *
      * @param  string $version
-     * @return self
+     * @return self|null
      */
     public function setVersion(?string $version): self
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -66,7 +66,7 @@ class Response
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options) : self
+    public function setOptions(array $options): self
     {
         // re-produce error state
         if (isset($options['error']) && is_array($options['error'])) {
@@ -102,7 +102,7 @@ class Response
      * @return void
      * @throws Exception\RuntimeException
      */
-    public function loadJson(string $json) : void
+    public function loadJson(string $json): void
     {
         try {
             $options = Json::decode($json, Json::TYPE_ARRAY);
@@ -127,7 +127,7 @@ class Response
      * @param  mixed $value
      * @return self
      */
-    public function setResult($value) : self
+    public function setResult($value): self
     {
         $this->result = $value;
         return $this;
@@ -151,7 +151,7 @@ class Response
      * @param  mixed $error
      * @return self
      */
-    public function setError(Error $error = null) : self
+    public function setError(Error $error = null): self
     {
         $this->error = $error;
         return $this;
@@ -162,7 +162,7 @@ class Response
      *
      * @return null|Error
      */
-    public function getError() : ?Error
+    public function getError(): ?Error
     {
         return $this->error;
     }
@@ -172,7 +172,7 @@ class Response
      *
      * @return bool
      */
-    public function isError() : bool
+    public function isError(): bool
     {
         return $this->getError() instanceof Error;
     }
@@ -183,7 +183,7 @@ class Response
      * @param  mixed $name
      * @return self
      */
-    public function setId($name) : self
+    public function setId($name): self
     {
         $this->id = $name;
         return $this;
@@ -205,7 +205,7 @@ class Response
      * @param  string $version
      * @return self
      */
-    public function setVersion(?string $version) : self
+    public function setVersion(?string $version): self
     {
         if ('2.0' == $version) {
             $this->version = '2.0';
@@ -221,7 +221,7 @@ class Response
      *
      * @return null|string
      */
-    public function getVersion() : ?string
+    public function getVersion(): ?string
     {
         return $this->version;
     }
@@ -264,7 +264,7 @@ class Response
      * @param mixed $args
      * @return self
      */
-    public function setArgs($args) : self
+    public function setArgs($args): self
     {
         $this->args = $args;
         return $this;
@@ -276,7 +276,7 @@ class Response
      * @param  Smd $serviceMap
      * @return self
      */
-    public function setServiceMap(Smd $serviceMap) : self
+    public function setServiceMap(Smd $serviceMap): self
     {
         $this->serviceMap = $serviceMap;
         return $this;
@@ -287,7 +287,7 @@ class Response
      *
      * @return Smd|null
      */
-    public function getServiceMap() : ?Smd
+    public function getServiceMap(): ?Smd
     {
         return $this->serviceMap;
     }
@@ -297,7 +297,7 @@ class Response
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->toJson();
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -98,7 +98,7 @@ class Response
      * @return void
      * @throws Exception\RuntimeException
      */
-    public function loadJson($json) : void
+    public function loadJson(string $json) : void
     {
         try {
             $options = Json::decode($json, Json::TYPE_ARRAY);
@@ -201,9 +201,8 @@ class Response
      * @param  string $version
      * @return self
      */
-    public function setVersion($version) : self
+    public function setVersion(string $version) : self
     {
-        $version = (string) $version;
         if ('2.0' == $version) {
             $this->version = '2.0';
             return $this;
@@ -273,7 +272,7 @@ class Response
      * @param  Smd $serviceMap
      * @return self
      */
-    public function setServiceMap($serviceMap) : self
+    public function setServiceMap(Smd $serviceMap) : self
     {
         $this->serviceMap = $serviceMap;
         return $this;

--- a/src/Response.php
+++ b/src/Response.php
@@ -77,6 +77,10 @@ class Response
 
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
+            if (! is_string($key)) {
+                continue;
+            }
+
             $method = 'set' . ucfirst($key);
             if (in_array($method, $methods)) {
                 $this->$method($value);

--- a/src/Response.php
+++ b/src/Response.php
@@ -66,7 +66,7 @@ class Response
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options) : self
     {
         // re-produce error state
         if (isset($options['error']) && is_array($options['error'])) {
@@ -98,7 +98,7 @@ class Response
      * @return void
      * @throws Exception\RuntimeException
      */
-    public function loadJson($json)
+    public function loadJson($json) : void
     {
         try {
             $options = Json::decode($json, Json::TYPE_ARRAY);
@@ -123,7 +123,7 @@ class Response
      * @param  mixed $value
      * @return self
      */
-    public function setResult($value)
+    public function setResult($value) : self
     {
         $this->result = $value;
         return $this;
@@ -147,7 +147,7 @@ class Response
      * @param  mixed $error
      * @return self
      */
-    public function setError(Error $error = null)
+    public function setError(Error $error = null) : self
     {
         $this->error = $error;
         return $this;
@@ -158,7 +158,7 @@ class Response
      *
      * @return null|Error
      */
-    public function getError()
+    public function getError() : ?Error
     {
         return $this->error;
     }
@@ -168,7 +168,7 @@ class Response
      *
      * @return bool
      */
-    public function isError()
+    public function isError() : bool
     {
         return $this->getError() instanceof Error;
     }
@@ -179,7 +179,7 @@ class Response
      * @param  mixed $name
      * @return self
      */
-    public function setId($name)
+    public function setId($name) : self
     {
         $this->id = $name;
         return $this;
@@ -201,7 +201,7 @@ class Response
      * @param  string $version
      * @return self
      */
-    public function setVersion($version)
+    public function setVersion($version) : self
     {
         $version = (string) $version;
         if ('2.0' == $version) {
@@ -218,7 +218,7 @@ class Response
      *
      * @return null|string
      */
-    public function getVersion()
+    public function getVersion() : ?string
     {
         return $this->version;
     }
@@ -228,7 +228,7 @@ class Response
      *
      * @return string
      */
-    public function toJson()
+    public function toJson(): string
     {
         $response = ['id' => $this->getId()];
 
@@ -261,7 +261,7 @@ class Response
      * @param mixed $args
      * @return self
      */
-    public function setArgs($args)
+    public function setArgs($args) : self
     {
         $this->args = $args;
         return $this;
@@ -273,7 +273,7 @@ class Response
      * @param  Smd $serviceMap
      * @return self
      */
-    public function setServiceMap($serviceMap)
+    public function setServiceMap($serviceMap) : self
     {
         $this->serviceMap = $serviceMap;
         return $this;
@@ -284,7 +284,7 @@ class Response
      *
      * @return Smd|null
      */
-    public function getServiceMap()
+    public function getServiceMap() : ?Smd
     {
         return $this->serviceMap;
     }
@@ -294,7 +294,7 @@ class Response
      *
      * @return string
      */
-    public function __toString()
+    public function __toString() : string
     {
         return $this->toJson();
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -207,7 +207,7 @@ class Response
      */
     public function setVersion(?string $version): self
     {
-        if ('2.0' == $version) {
+        if ('2.0' === $version) {
             $this->version = '2.0';
             return $this;
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -274,9 +274,9 @@ class Response
      * Set service map object.
      *
      * @param  Smd $serviceMap
-     * @return self
+     * @return self|null
      */
-    public function setServiceMap(Smd $serviceMap): self
+    public function setServiceMap(?Smd $serviceMap): self
     {
         $this->serviceMap = $serviceMap;
         return $this;

--- a/src/Response.php
+++ b/src/Response.php
@@ -201,7 +201,7 @@ class Response
      * @param  string $version
      * @return self
      */
-    public function setVersion(string $version) : self
+    public function setVersion(?string $version) : self
     {
         if ('2.0' == $version) {
             $this->version = '2.0';

--- a/src/Response.php
+++ b/src/Response.php
@@ -82,7 +82,7 @@ class Response
             }
 
             $method = 'set' . ucfirst($key);
-            if (in_array($method, $methods)) {
+            if (in_array($method, $methods, true)) {
                 $this->$method($value);
                 continue;
             }

--- a/src/Response.php
+++ b/src/Response.php
@@ -13,6 +13,11 @@ namespace Laminas\Json\Server;
 use Laminas\Json\Exception\RuntimeException;
 use Laminas\Json\Json;
 
+use function get_class_methods;
+use function in_array;
+use function is_array;
+use function ucfirst;
+
 class Response
 {
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Json\Exception\RuntimeException;

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Response;
 
 use Laminas\Json\Server\Response as JsonResponse;

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -26,7 +26,7 @@ class Http extends JsonResponse
      *
      * @return string
      */
-    public function toJson()
+    public function toJson(): string
     {
         $this->sendHeaders();
 
@@ -49,7 +49,7 @@ class Http extends JsonResponse
      *
      * @return void
      */
-    public function sendHeaders()
+    public function sendHeaders() : void
     {
         if (headers_sent()) {
             return;

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -49,7 +49,7 @@ class Http extends JsonResponse
      *
      * @return void
      */
-    public function sendHeaders() : void
+    public function sendHeaders(): void
     {
         if (headers_sent()) {
             return;

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -12,6 +12,9 @@ namespace Laminas\Json\Server\Response;
 
 use Laminas\Json\Server\Response as JsonResponse;
 
+use function header;
+use function headers_sent;
+
 class Http extends JsonResponse
 {
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -333,7 +333,7 @@ class Server extends AbstractServer
      * @param  array $args
      * @return mixed
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         if (! preg_match('/^(set|get)/', $method, $matches)) {
             return;

--- a/src/Server.php
+++ b/src/Server.php
@@ -101,7 +101,7 @@ class Server extends AbstractServer
      * @return Server
      * @throws Exception\InvalidArgumentException If function invalid or not callable.
      */
-    public function addFunction($function, $namespace = '')
+    public function addFunction($function, $namespace = '') : Server
     {
         if (! is_callable($function)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -152,7 +152,7 @@ class Server extends AbstractServer
      * @param  mixed $argv Ignored
      * @return Server
      */
-    public function setClass($class, $namespace = '', $argv = null)
+    public function setClass($class, $namespace = '', $argv = null) : Server
     {
         if (2 < func_num_args()) {
             $argv = func_get_args();
@@ -177,7 +177,7 @@ class Server extends AbstractServer
      * @param  mixed $data
      * @return Error
      */
-    public function fault($fault = null, $code = 404, $data = null)
+    public function fault($fault = null, $code = 404, $data = null) : Error
     {
         $error = new Error($fault, $code, $data);
         $this->getResponse()->setError($error);
@@ -191,7 +191,7 @@ class Server extends AbstractServer
      * @return null|Response
      * @throws Exception\InvalidArgumentException
      */
-    public function handle($request = false)
+    public function handle($request = false) : ?Response
     {
         if ((false !== $request) && ! $request instanceof Request) {
             throw new Exception\InvalidArgumentException('Invalid request type provided; cannot handle');
@@ -224,7 +224,7 @@ class Server extends AbstractServer
      * @throws Exception\InvalidArgumentException
      * @return void
      */
-    public function loadFunctions($definition)
+    public function loadFunctions($definition) : void
     {
         if (! is_array($definition) && (! $definition instanceof Definition)) {
             throw new Exception\InvalidArgumentException('Invalid definition provided to loadFunctions()');
@@ -239,7 +239,7 @@ class Server extends AbstractServer
     /**
      * Cache/persist server (unused)
      */
-    public function setPersistence($mode)
+    public function setPersistence($mode) : void
     {
     }
 
@@ -249,7 +249,7 @@ class Server extends AbstractServer
      * @param  Request $request
      * @return self
      */
-    public function setRequest(Request $request)
+    public function setRequest(Request $request) : self
     {
         $this->request = $request;
         return $this;
@@ -262,7 +262,7 @@ class Server extends AbstractServer
      *
      * @return Request
      */
-    public function getRequest()
+    public function getRequest() : Request
     {
         if (null === $this->request) {
             $this->setRequest(new Request\Http());
@@ -277,7 +277,7 @@ class Server extends AbstractServer
      * @param  Response $response
      * @return self
      */
-    public function setResponse(Response $response)
+    public function setResponse(Response $response) : self
     {
         $this->response = $response;
         return $this;
@@ -290,7 +290,7 @@ class Server extends AbstractServer
      *
      * @return Response
      */
-    public function getResponse()
+    public function getResponse() : Response
     {
         if (null === $this->response) {
             $this->setResponse(new Response\Http());
@@ -310,7 +310,7 @@ class Server extends AbstractServer
      * @param  bool $flag
      * @return self
      */
-    public function setReturnResponse($flag = true)
+    public function setReturnResponse($flag = true) : self
     {
         $this->returnResponse = (bool) $flag;
         return $this;
@@ -321,7 +321,7 @@ class Server extends AbstractServer
      *
      * @return bool
      */
-    public function getReturnResponse()
+    public function getReturnResponse() : bool
     {
         return $this->returnResponse;
     }
@@ -359,7 +359,7 @@ class Server extends AbstractServer
      *
      * @return Smd
      */
-    public function getServiceMap()
+    public function getServiceMap() : Smd
     {
         if (null === $this->serviceMap) {
             $this->serviceMap = new Smd();
@@ -373,7 +373,7 @@ class Server extends AbstractServer
      * @param  Method\Definition $method
      * @return void
      */
-    protected function addMethodServiceMap(Method\Definition $method)
+    protected function addMethodServiceMap(Method\Definition $method) : void
     {
         $serviceInfo = [
             'name'   => $method->getName(),
@@ -400,7 +400,7 @@ class Server extends AbstractServer
      * @param  string $type
      * @return string
      */
-    protected function _fixType($type)
+    protected function _fixType($type) : string
     {
         return $type;
     }
@@ -413,7 +413,7 @@ class Server extends AbstractServer
      * @param  array $params
      * @return array
      */
-    protected function getDefaultParams(array $args, array $params)
+    protected function getDefaultParams(array $args, array $params) : array
     {
         if (false === $this->isAssociative($args)) {
             $params = array_slice($params, count($args));
@@ -436,7 +436,7 @@ class Server extends AbstractServer
      * @param array $array
      * @return bool
      */
-    private function isAssociative(array $array)
+    private function isAssociative(array $array) : bool
     {
         $keys = array_keys($array);
         return ($keys != array_keys($keys));
@@ -503,7 +503,7 @@ class Server extends AbstractServer
      *
      * @return Response
      */
-    protected function getReadyResponse()
+    protected function getReadyResponse() : Response
     {
         $request  = $this->getRequest();
         $response = $this->getResponse();
@@ -547,7 +547,7 @@ class Server extends AbstractServer
      *
      * @return array
      */
-    protected function getSmdMethods()
+    protected function getSmdMethods() : array
     {
         if (null !== $this->smdMethods) {
             return $this->smdMethods;
@@ -575,7 +575,7 @@ class Server extends AbstractServer
      *
      * @return void
      */
-    protected function handleRequest()
+    protected function handleRequest() : void
     {
         $request = $this->getRequest();
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -339,7 +339,7 @@ class Server extends AbstractServer
             return;
         }
 
-        if (! in_array($method, $this->getSmdMethods())) {
+        if (! in_array($method, $this->getSmdMethods(), true)) {
             return;
         }
 
@@ -476,7 +476,7 @@ class Server extends AbstractServer
                 $newType = $parameter->getType();
 
                 if (is_array($params[$key]['type'])
-                    && in_array($newType, $params[$key]['type'])
+                    && in_array($newType, $params[$key]['type'], true)
                 ) {
                     continue;
                 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -575,7 +575,7 @@ class Server extends AbstractServer
      *
      * @return Error
      */
-    protected function handleRequest() : Error
+    protected function handleRequest() : ?Error
     {
         $request = $this->getRequest();
 
@@ -583,7 +583,7 @@ class Server extends AbstractServer
             return $this->fault('Parse error', Error::ERROR_PARSE);
         }
 
-        if (! $request->isMethodError() && null === $request->getMethod()) {
+        if (! $request->isMethodError() && '' === $request->getMethod()) {
             return $this->fault('Invalid Request', Error::ERROR_INVALID_REQUEST);
         }
 
@@ -616,6 +616,8 @@ class Server extends AbstractServer
         }
 
         $this->getResponse()->setResult($result);
+
+        return null;
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -573,7 +573,7 @@ class Server extends AbstractServer
     /**
      * Internal method for handling request.
      *
-     * @return Error
+     * @return Error|null
      */
     protected function handleRequest(): ?Error
     {

--- a/src/Server.php
+++ b/src/Server.php
@@ -210,7 +210,7 @@ class Server extends AbstractServer
         // Emit response?
         if (! $this->returnResponse) {
             echo $response;
-            return;
+            return null;
         }
 
         // or return it?
@@ -573,9 +573,9 @@ class Server extends AbstractServer
     /**
      * Internal method for handling request.
      *
-     * @return void
+     * @return Error
      */
-    protected function handleRequest() : void
+    protected function handleRequest() : Error
     {
         $request = $this->getRequest();
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -18,6 +18,28 @@ use Laminas\Server\Reflection;
 use ReflectionFunction;
 use ReflectionMethod;
 
+use function array_key_exists;
+use function array_keys;
+use function array_push;
+use function array_reduce;
+use function array_shift;
+use function array_slice;
+use function count;
+use function func_get_args;
+use function func_num_args;
+use function get_class;
+use function get_class_methods;
+use function gettype;
+use function in_array;
+use function is_array;
+use function is_callable;
+use function is_object;
+use function is_string;
+use function key;
+use function preg_match;
+use function sprintf;
+use function strstr;
+
 class Server extends AbstractServer
 {
     /**#@+

--- a/src/Server.php
+++ b/src/Server.php
@@ -101,7 +101,7 @@ class Server extends AbstractServer
      * @return Server
      * @throws Exception\InvalidArgumentException If function invalid or not callable.
      */
-    public function addFunction($function, $namespace = '') : Server
+    public function addFunction($function, $namespace = ''): Server
     {
         if (! is_callable($function)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -152,7 +152,7 @@ class Server extends AbstractServer
      * @param  mixed $argv Ignored
      * @return Server
      */
-    public function setClass($class, $namespace = '', $argv = null) : Server
+    public function setClass($class, $namespace = '', $argv = null): Server
     {
         if (2 < func_num_args()) {
             $argv = func_get_args();
@@ -177,7 +177,7 @@ class Server extends AbstractServer
      * @param  mixed $data
      * @return Error
      */
-    public function fault($fault = null, $code = 404, $data = null) : Error
+    public function fault($fault = null, $code = 404, $data = null): Error
     {
         $error = new Error($fault, $code, $data);
         $this->getResponse()->setError($error);
@@ -191,7 +191,7 @@ class Server extends AbstractServer
      * @return null|Response
      * @throws Exception\InvalidArgumentException
      */
-    public function handle($request = false) : ?Response
+    public function handle($request = false): ?Response
     {
         if ((false !== $request) && ! $request instanceof Request) {
             throw new Exception\InvalidArgumentException('Invalid request type provided; cannot handle');
@@ -224,7 +224,7 @@ class Server extends AbstractServer
      * @throws Exception\InvalidArgumentException
      * @return void
      */
-    public function loadFunctions($definition) : void
+    public function loadFunctions($definition): void
     {
         if (! is_array($definition) && (! $definition instanceof Definition)) {
             throw new Exception\InvalidArgumentException('Invalid definition provided to loadFunctions()');
@@ -239,7 +239,7 @@ class Server extends AbstractServer
     /**
      * Cache/persist server (unused)
      */
-    public function setPersistence($mode) : void
+    public function setPersistence($mode): void
     {
     }
 
@@ -249,7 +249,7 @@ class Server extends AbstractServer
      * @param  Request $request
      * @return self
      */
-    public function setRequest(Request $request) : self
+    public function setRequest(Request $request): self
     {
         $this->request = $request;
         return $this;
@@ -262,7 +262,7 @@ class Server extends AbstractServer
      *
      * @return Request
      */
-    public function getRequest() : Request
+    public function getRequest(): Request
     {
         if (null === $this->request) {
             $this->setRequest(new Request\Http());
@@ -277,7 +277,7 @@ class Server extends AbstractServer
      * @param  Response $response
      * @return self
      */
-    public function setResponse(Response $response) : self
+    public function setResponse(Response $response): self
     {
         $this->response = $response;
         return $this;
@@ -290,7 +290,7 @@ class Server extends AbstractServer
      *
      * @return Response
      */
-    public function getResponse() : Response
+    public function getResponse(): Response
     {
         if (null === $this->response) {
             $this->setResponse(new Response\Http());
@@ -310,7 +310,7 @@ class Server extends AbstractServer
      * @param  bool $flag
      * @return self
      */
-    public function setReturnResponse($flag = true) : self
+    public function setReturnResponse($flag = true): self
     {
         $this->returnResponse = (bool) $flag;
         return $this;
@@ -321,7 +321,7 @@ class Server extends AbstractServer
      *
      * @return bool
      */
-    public function getReturnResponse() : bool
+    public function getReturnResponse(): bool
     {
         return $this->returnResponse;
     }
@@ -359,7 +359,7 @@ class Server extends AbstractServer
      *
      * @return Smd
      */
-    public function getServiceMap() : Smd
+    public function getServiceMap(): Smd
     {
         if (null === $this->serviceMap) {
             $this->serviceMap = new Smd();
@@ -373,7 +373,7 @@ class Server extends AbstractServer
      * @param  Method\Definition $method
      * @return void
      */
-    protected function addMethodServiceMap(Method\Definition $method) : void
+    protected function addMethodServiceMap(Method\Definition $method): void
     {
         $serviceInfo = [
             'name'   => $method->getName(),
@@ -400,7 +400,7 @@ class Server extends AbstractServer
      * @param  string $type
      * @return string
      */
-    protected function _fixType($type) : string
+    protected function _fixType($type): string
     {
         return $type;
     }
@@ -413,7 +413,7 @@ class Server extends AbstractServer
      * @param  array $params
      * @return array
      */
-    protected function getDefaultParams(array $args, array $params) : array
+    protected function getDefaultParams(array $args, array $params): array
     {
         if (false === $this->isAssociative($args)) {
             $params = array_slice($params, count($args));
@@ -436,7 +436,7 @@ class Server extends AbstractServer
      * @param array $array
      * @return bool
      */
-    private function isAssociative(array $array) : bool
+    private function isAssociative(array $array): bool
     {
         $keys = array_keys($array);
         return ($keys != array_keys($keys));
@@ -503,7 +503,7 @@ class Server extends AbstractServer
      *
      * @return Response
      */
-    protected function getReadyResponse() : Response
+    protected function getReadyResponse(): Response
     {
         $request  = $this->getRequest();
         $response = $this->getResponse();
@@ -547,7 +547,7 @@ class Server extends AbstractServer
      *
      * @return array
      */
-    protected function getSmdMethods() : array
+    protected function getSmdMethods(): array
     {
         if (null !== $this->smdMethods) {
             return $this->smdMethods;
@@ -575,7 +575,7 @@ class Server extends AbstractServer
      *
      * @return Error
      */
-    protected function handleRequest() : ?Error
+    protected function handleRequest(): ?Error
     {
         $request = $this->getRequest();
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -127,7 +127,7 @@ class Server extends AbstractServer
             $methods = $reflection->getMethods();
             $found   = false;
             foreach ($methods as $method) {
-                if ($action == $method->getName()) {
+                if ($action === $method->getName()) {
                     $found = true;
                     break;
                 }
@@ -343,7 +343,7 @@ class Server extends AbstractServer
             return;
         }
 
-        if ('set' == $matches[1]) {
+        if ('set' === $matches[1]) {
             $value = array_shift($args);
             $this->getServiceMap()->$method($value);
             return $this;
@@ -533,7 +533,7 @@ class Server extends AbstractServer
             $return[] = $prototype->getReturnType();
         }
 
-        if (1 == count($return)) {
+        if (1 === count($return)) {
             return $return[0];
         }
 
@@ -658,7 +658,7 @@ class Server extends AbstractServer
         }
 
         $callback = $invokable->getCallback();
-        $reflection = 'function' == $callback->getType()
+        $reflection = 'function' === $callback->getType()
             ? new ReflectionFunction($callback->getFunction())
             : new ReflectionMethod($callback->getClass(), $callback->getMethod());
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Exception as PhpException;

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Json\Json;

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -114,7 +114,7 @@ class Smd
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options) : self
     {
         foreach ($options as $key => $value) {
             $method = 'set' . ucfirst($key);
@@ -134,7 +134,7 @@ class Smd
      * @return self
       * @throws InvalidArgumentException
      */
-    public function setTransport($transport)
+    public function setTransport($transport) : self
     {
         if (! in_array($transport, $this->transportTypes)) {
             throw new InvalidArgumentException("Invalid transport '{$transport}' specified");
@@ -149,7 +149,7 @@ class Smd
      *
      * @return string
      */
-    public function getTransport()
+    public function getTransport() : string
     {
         return $this->transport;
     }
@@ -161,7 +161,7 @@ class Smd
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setEnvelope($envelopeType)
+    public function setEnvelope($envelopeType) : self
     {
         if (! in_array($envelopeType, $this->envelopeTypes)) {
             throw new InvalidArgumentException("Invalid envelope type '{$envelopeType}'");
@@ -176,7 +176,7 @@ class Smd
      *
      * @return string
      */
-    public function getEnvelope()
+    public function getEnvelope() : string
     {
         return $this->envelope;
     }
@@ -188,7 +188,7 @@ class Smd
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setContentType($type)
+    public function setContentType($type) : self
     {
         if (! preg_match($this->contentTypeRegex, $type)) {
             throw new InvalidArgumentException("Invalid content type '{$type}' specified");
@@ -205,7 +205,7 @@ class Smd
      *
      * @return string
      */
-    public function getContentType()
+    public function getContentType() : string
     {
         return $this->contentType;
     }
@@ -216,7 +216,7 @@ class Smd
      * @param  string $target
      * @return self
      */
-    public function setTarget($target)
+    public function setTarget($target) : self
     {
         $this->target = (string) $target;
         return $this;
@@ -227,7 +227,7 @@ class Smd
      *
      * @return string
      */
-    public function getTarget()
+    public function getTarget() : string
     {
         return $this->target;
     }
@@ -238,7 +238,7 @@ class Smd
      * @param  string $id
      * @return self
      */
-    public function setId($id)
+    public function setId($id) : self
     {
         $this->id = (string) $id;
         return $this;
@@ -249,7 +249,7 @@ class Smd
      *
      * @return string
      */
-    public function getId()
+    public function getId() : string
     {
         return $this->id;
     }
@@ -260,7 +260,7 @@ class Smd
      * @param  string $description
      * @return self
      */
-    public function setDescription($description)
+    public function setDescription($description) : self
     {
         $this->description = (string) $description;
         return $this->description;
@@ -271,7 +271,7 @@ class Smd
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription() : string
     {
         return $this->description;
     }
@@ -282,7 +282,7 @@ class Smd
      * @param  bool $flag
      * @return self
      */
-    public function setDojoCompatible($flag)
+    public function setDojoCompatible($flag) : self
     {
         $this->dojoCompatible = (bool) $flag;
         return $this;
@@ -293,7 +293,7 @@ class Smd
      *
      * @return bool
      */
-    public function isDojoCompatible()
+    public function isDojoCompatible() : bool
     {
         return $this->dojoCompatible;
     }
@@ -306,7 +306,7 @@ class Smd
      * @throws RuntimeException
      * @throws InvalidArgumentException
      */
-    public function addService($service)
+    public function addService($service) : self
     {
         if (is_array($service)) {
             $service = new Smd\Service($service);
@@ -332,7 +332,7 @@ class Smd
      * @param  array $services
      * @return self
      */
-    public function addServices(array $services)
+    public function addServices(array $services) : self
     {
         foreach ($services as $service) {
             $this->addService($service);
@@ -347,7 +347,7 @@ class Smd
      * @param  array $services
      * @return self
      */
-    public function setServices(array $services)
+    public function setServices(array $services) : self
     {
         $this->services = [];
         return $this->addServices($services);
@@ -373,7 +373,7 @@ class Smd
      *
      * @return array
      */
-    public function getServices()
+    public function getServices() : array
     {
         return $this->services;
     }
@@ -384,7 +384,7 @@ class Smd
      * @param  string $name
      * @return bool
      */
-    public function removeService($name)
+    public function removeService($name) : bool
     {
         if (! array_key_exists($name, $this->services)) {
             return false;
@@ -399,7 +399,7 @@ class Smd
      *
      * @return array
      */
-    public function toArray()
+    public function toArray() : array
     {
         if ($this->isDojoCompatible()) {
             return $this->toDojoArray();
@@ -439,7 +439,7 @@ class Smd
      *
      * @return array
      */
-    public function toDojoArray()
+    public function toDojoArray() : array
     {
         $SMDVersion  = '.1';
         $serviceType = 'JSON-RPC';
@@ -481,7 +481,7 @@ class Smd
      *
      * @return string
      */
-    public function toJson()
+    public function toJson() : string
     {
         return Json::encode($this->toArray());
     }
@@ -491,7 +491,7 @@ class Smd
      *
      * @return string
      */
-    public function __toString()
+    public function __toString() : string
     {
         return $this->toJson();
     }

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -258,9 +258,9 @@ class Smd
      * Set service description.
      *
      * @param  string $description
-     * @return self
+     * @return string
      */
-    public function setDescription($description) : self
+    public function setDescription($description) : string
     {
         $this->description = (string) $description;
         return $this->description;

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -132,7 +132,7 @@ class Smd
      *
      * @param  string $transport
      * @return self
-      * @throws InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setTransport(string $transport): self
     {

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -114,7 +114,7 @@ class Smd
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options) : self
+    public function setOptions(array $options): self
     {
         foreach ($options as $key => $value) {
             $method = 'set' . ucfirst($key);
@@ -134,7 +134,7 @@ class Smd
      * @return self
       * @throws InvalidArgumentException
      */
-    public function setTransport(string $transport) : self
+    public function setTransport(string $transport): self
     {
         if (! in_array($transport, $this->transportTypes)) {
             throw new InvalidArgumentException("Invalid transport '{$transport}' specified");
@@ -149,7 +149,7 @@ class Smd
      *
      * @return string
      */
-    public function getTransport() : string
+    public function getTransport(): string
     {
         return $this->transport;
     }
@@ -161,7 +161,7 @@ class Smd
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setEnvelope(string $envelopeType) : self
+    public function setEnvelope(string $envelopeType): self
     {
         if (! in_array($envelopeType, $this->envelopeTypes)) {
             throw new InvalidArgumentException("Invalid envelope type '{$envelopeType}'");
@@ -176,7 +176,7 @@ class Smd
      *
      * @return string
      */
-    public function getEnvelope() : string
+    public function getEnvelope(): string
     {
         return $this->envelope;
     }
@@ -188,7 +188,7 @@ class Smd
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setContentType(string $type) : self
+    public function setContentType(string $type): self
     {
         if (! preg_match($this->contentTypeRegex, $type)) {
             throw new InvalidArgumentException("Invalid content type '{$type}' specified");
@@ -205,7 +205,7 @@ class Smd
      *
      * @return string
      */
-    public function getContentType() : string
+    public function getContentType(): string
     {
         return $this->contentType;
     }
@@ -216,7 +216,7 @@ class Smd
      * @param  string $target
      * @return self
      */
-    public function setTarget(string $target) : self
+    public function setTarget(string $target): self
     {
         $this->target = $target;
         return $this;
@@ -227,7 +227,7 @@ class Smd
      *
      * @return string
      */
-    public function getTarget() : string
+    public function getTarget(): string
     {
         return $this->target;
     }
@@ -238,7 +238,7 @@ class Smd
      * @param  string $id
      * @return self
      */
-    public function setId(string $id) : self
+    public function setId(string $id): self
     {
         $this->id = $id;
         return $this;
@@ -249,7 +249,7 @@ class Smd
      *
      * @return string
      */
-    public function getId() : string
+    public function getId(): string
     {
         return $this->id;
     }
@@ -260,7 +260,7 @@ class Smd
      * @param  string $description
      * @return self
      */
-    public function setDescription(string $description) : self
+    public function setDescription(string $description): self
     {
         $this->description = $description;
         return $this;
@@ -271,7 +271,7 @@ class Smd
      *
      * @return string
      */
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -282,7 +282,7 @@ class Smd
      * @param  bool $flag
      * @return self
      */
-    public function setDojoCompatible(bool $flag) : self
+    public function setDojoCompatible(bool $flag): self
     {
         $this->dojoCompatible = $flag;
         return $this;
@@ -293,7 +293,7 @@ class Smd
      *
      * @return bool
      */
-    public function isDojoCompatible() : bool
+    public function isDojoCompatible(): bool
     {
         return $this->dojoCompatible;
     }
@@ -306,7 +306,7 @@ class Smd
      * @throws RuntimeException
      * @throws InvalidArgumentException
      */
-    public function addService($service) : self
+    public function addService($service): self
     {
         if (is_array($service)) {
             $service = new Smd\Service($service);
@@ -332,7 +332,7 @@ class Smd
      * @param  array $services
      * @return self
      */
-    public function addServices(array $services) : self
+    public function addServices(array $services): self
     {
         foreach ($services as $service) {
             $this->addService($service);
@@ -347,7 +347,7 @@ class Smd
      * @param  array $services
      * @return self
      */
-    public function setServices(array $services) : self
+    public function setServices(array $services): self
     {
         $this->services = [];
         return $this->addServices($services);
@@ -373,7 +373,7 @@ class Smd
      *
      * @return array
      */
-    public function getServices() : array
+    public function getServices(): array
     {
         return $this->services;
     }
@@ -384,7 +384,7 @@ class Smd
      * @param  string $name
      * @return bool
      */
-    public function removeService(string $name) : bool
+    public function removeService(string $name): bool
     {
         if (! array_key_exists($name, $this->services)) {
             return false;
@@ -399,7 +399,7 @@ class Smd
      *
      * @return array
      */
-    public function toArray() : array
+    public function toArray(): array
     {
         if ($this->isDojoCompatible()) {
             return $this->toDojoArray();
@@ -439,7 +439,7 @@ class Smd
      *
      * @return array
      */
-    public function toDojoArray() : array
+    public function toDojoArray(): array
     {
         $SMDVersion  = '.1';
         $serviceType = 'JSON-RPC';
@@ -481,7 +481,7 @@ class Smd
      *
      * @return string
      */
-    public function toJson() : string
+    public function toJson(): string
     {
         return Json::encode($this->toArray());
     }
@@ -491,7 +491,7 @@ class Smd
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->toJson();
     }

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -136,7 +136,7 @@ class Smd
      */
     public function setTransport(string $transport): self
     {
-        if (! in_array($transport, $this->transportTypes)) {
+        if (! in_array($transport, $this->transportTypes, true)) {
             throw new InvalidArgumentException("Invalid transport '{$transport}' specified");
         }
 
@@ -163,7 +163,7 @@ class Smd
      */
     public function setEnvelope(string $envelopeType): self
     {
-        if (! in_array($envelopeType, $this->envelopeTypes)) {
+        if (! in_array($envelopeType, $this->envelopeTypes, true)) {
             throw new InvalidArgumentException("Invalid envelope type '{$envelopeType}'");
         }
 

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -14,6 +14,14 @@ use Laminas\Json\Json;
 use Laminas\Json\Server\Exception\InvalidArgumentException;
 use Laminas\Json\Server\Exception\RuntimeException;
 
+use function array_key_exists;
+use function compact;
+use function in_array;
+use function is_array;
+use function method_exists;
+use function preg_match;
+use function ucfirst;
+
 class Smd
 {
     const ENV_JSONRPC_1 = 'JSON-RPC-1.0';
@@ -124,7 +132,7 @@ class Smd
      *
      * @param  string $transport
      * @return self
-     * @throws Exception\InvalidArgumentException
+      * @throws InvalidArgumentException
      */
     public function setTransport($transport)
     {
@@ -151,7 +159,7 @@ class Smd
      *
      * @param  string $envelopeType
      * @return self
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setEnvelope($envelopeType)
     {
@@ -178,7 +186,7 @@ class Smd
      *
      * @param  string $type
      * @return self
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setContentType($type)
     {
@@ -295,8 +303,8 @@ class Smd
      *
      * @param Smd\Service|array $service
      * @return self
-     * @throws Exception\RuntimeException
-     * @throws Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function addService($service)
     {

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -47,7 +47,7 @@ class Smd
      *
      * @var string
      */
-    protected $description;
+    protected $description = '';
 
     /**
      * Generate Dojo-compatible SMD?
@@ -78,7 +78,7 @@ class Smd
      *
      * @var string
      */
-    protected $id;
+    protected $id = '';
 
     /**
      * Services offered.
@@ -92,7 +92,7 @@ class Smd
      *
      * @var string
      */
-    protected $target;
+    protected $target = '';
 
     /**
      * Global transport.
@@ -258,12 +258,12 @@ class Smd
      * Set service description.
      *
      * @param  string $description
-     * @return string
+     * @return self
      */
-    public function setDescription(string $description) : string
+    public function setDescription(string $description) : self
     {
         $this->description = $description;
-        return $this->description;
+        return $this;
     }
 
     /**

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -134,7 +134,7 @@ class Smd
      * @return self
       * @throws InvalidArgumentException
      */
-    public function setTransport($transport) : self
+    public function setTransport(string $transport) : self
     {
         if (! in_array($transport, $this->transportTypes)) {
             throw new InvalidArgumentException("Invalid transport '{$transport}' specified");
@@ -161,7 +161,7 @@ class Smd
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setEnvelope($envelopeType) : self
+    public function setEnvelope(string $envelopeType) : self
     {
         if (! in_array($envelopeType, $this->envelopeTypes)) {
             throw new InvalidArgumentException("Invalid envelope type '{$envelopeType}'");
@@ -188,7 +188,7 @@ class Smd
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setContentType($type) : self
+    public function setContentType(string $type) : self
     {
         if (! preg_match($this->contentTypeRegex, $type)) {
             throw new InvalidArgumentException("Invalid content type '{$type}' specified");
@@ -216,9 +216,9 @@ class Smd
      * @param  string $target
      * @return self
      */
-    public function setTarget($target) : self
+    public function setTarget(string $target) : self
     {
-        $this->target = (string) $target;
+        $this->target = $target;
         return $this;
     }
 
@@ -238,9 +238,9 @@ class Smd
      * @param  string $id
      * @return self
      */
-    public function setId($id) : self
+    public function setId(string $id) : self
     {
-        $this->id = (string) $id;
+        $this->id = $id;
         return $this;
     }
 
@@ -260,9 +260,9 @@ class Smd
      * @param  string $description
      * @return string
      */
-    public function setDescription($description) : string
+    public function setDescription(string $description) : string
     {
-        $this->description = (string) $description;
+        $this->description = $description;
         return $this->description;
     }
 
@@ -282,9 +282,9 @@ class Smd
      * @param  bool $flag
      * @return self
      */
-    public function setDojoCompatible($flag) : self
+    public function setDojoCompatible(bool $flag) : self
     {
-        $this->dojoCompatible = (bool) $flag;
+        $this->dojoCompatible = $flag;
         return $this;
     }
 
@@ -359,7 +359,7 @@ class Smd
      * @param  string $name
      * @return bool|Smd\Service
      */
-    public function getService($name)
+    public function getService(string $name)
     {
         if (! array_key_exists($name, $this->services)) {
             return false;
@@ -384,7 +384,7 @@ class Smd
      * @param  string $name
      * @return bool
      */
-    public function removeService($name) : bool
+    public function removeService(string $name) : bool
     {
         if (! array_key_exists($name, $this->services)) {
             return false;

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -174,9 +174,8 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setName($name) : self
+    public function setName(string $name) : self
     {
-        $name = (string) $name;
         if (! preg_match($this->nameRegex, $name)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid name "%s" provided for service; must follow PHP method naming conventions',
@@ -207,7 +206,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setTransport($transport) : self
+    public function setTransport(string $transport) : self
     {
         if (! in_array($transport, $this->transportTypes)) {
             throw new InvalidArgumentException(sprintf(
@@ -237,9 +236,9 @@ class Service
      * @param  string  $target
      * @return self
      */
-    public function setTarget($target) : self
+    public function setTarget(string $target) : self
     {
-        $this->target = (string) $target;
+        $this->target = $target;
         return $this;
     }
 
@@ -260,7 +259,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setEnvelope($envelopeType) : self
+    public function setEnvelope(string $envelopeType) : self
     {
         if (! in_array($envelopeType, $this->envelopeTypes)) {
             throw new InvalidArgumentException(sprintf(
@@ -293,7 +292,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function addParam($type, array $options = [], $order = null) : self
+    public function addParam($type, array $options = [], ?int $order = null) : self
     {
         if (! is_string($type) && ! is_array($type)) {
             throw new InvalidArgumentException('Invalid param type provided');
@@ -488,7 +487,7 @@ class Service
      * @return string
      * @throws InvalidArgumentException
      */
-    protected function validateParamType($type, $isReturn = false) : string
+    protected function validateParamType(string $type, bool $isReturn = false) : string
     {
         if (! is_string($type)) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -38,17 +38,30 @@ use function ucfirst;
  */
 class Service
 {
-    /**#@+
-     * Service metadata
-     *
+    /**
      * @var string
      */
     protected $envelope  = Smd::ENV_JSONRPC_1;
+
+    /**
+     * @var string
+     */
     protected $name = '';
+
+    /**
+     * @var string|array
+     */
     protected $return;
+
+    /**
+     * @var string
+     */
     protected $target = '';
+
+    /**
+     * @var string
+     */
     protected $transport = 'POST';
-    /**#@-*/
 
     /**
      * Allowed envelope types.

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -54,9 +54,9 @@ class Service
     protected $return;
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $target = '';
+    protected $target;
 
     /**
      * @var string
@@ -246,10 +246,10 @@ class Service
     /**
      * Set service target.
      *
-     * @param  string  $target
+     * @param  string|null $target
      * @return self
      */
-    public function setTarget(string $target): self
+    public function setTarget(?string $target): self
     {
         $this->target = $target;
         return $this;
@@ -258,9 +258,9 @@ class Service
     /**
      * Get service target.
      *
-     * @return string
+     * @return string|null
      */
-    public function getTarget(): string
+    public function getTarget(): ?string
     {
         return $this->target;
     }
@@ -463,7 +463,7 @@ class Service
         $returns    = $this->getReturn();
         $name       = $this->getName();
 
-        if ('' === $target) {
+        if (empty($target)) {
             return compact('envelope', 'transport', 'name', 'parameters', 'returns');
         }
 

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -167,7 +167,7 @@ class Service
     {
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
-            if ('options' == strtolower($key)) {
+            if ('options' === strtolower($key)) {
                 continue;
             }
 
@@ -514,7 +514,7 @@ class Service
         }
 
         $paramType = $this->paramMap[$type];
-        if (! $isReturn && ('null' == $paramType)) {
+        if (! $isReturn && ('null' === $paramType)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid param type provided ("%s")',
                 $type

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -172,7 +172,7 @@ class Service
             }
 
             $method = 'set' . ucfirst($key);
-            if (in_array($method, $methods)) {
+            if (in_array($method, $methods, true)) {
                 $this->$method($value);
             }
         }
@@ -221,7 +221,7 @@ class Service
      */
     public function setTransport(string $transport): self
     {
-        if (! in_array($transport, $this->transportTypes)) {
+        if (! in_array($transport, $this->transportTypes, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid transport "%s"; please select one of (%s)',
                 $transport,
@@ -274,7 +274,7 @@ class Service
      */
     public function setEnvelope(string $envelopeType): self
     {
-        if (! in_array($envelopeType, $this->envelopeTypes)) {
+        if (! in_array($envelopeType, $this->envelopeTypes, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid envelope type "%s"; please specify one of (%s)',
                 $envelopeType,
@@ -323,7 +323,7 @@ class Service
 
         $paramOptions = ['type' => $type];
         foreach ($options as $key => $value) {
-            if (in_array($key, array_keys($this->paramOptionTypes))) {
+            if (in_array($key, array_keys($this->paramOptionTypes), true)) {
                 if (null !== ($callback = $this->paramOptionTypes[$key])) {
                     if (! $callback($value)) {
                         continue;

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Smd;
 
 use Laminas\Json\Json;

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -139,7 +139,7 @@ class Service
             $this->setOptions($spec);
         }
 
-        if ('' == $this->getName()) {
+        if ('' === $this->getName()) {
             throw new InvalidArgumentException('SMD service description requires a name; none provided');
         }
     }

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -502,13 +502,6 @@ class Service
      */
     protected function validateParamType(string $type, bool $isReturn = false): string
     {
-        if (! is_string($type)) {
-            throw new InvalidArgumentException(sprintf(
-                'Invalid param type provided ("%s")',
-                $type
-            ));
-        }
-
         if (! array_key_exists($type, $this->paramMap)) {
             $type = 'object';
         }

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -150,7 +150,7 @@ class Service
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options) : self
+    public function setOptions(array $options): self
     {
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
@@ -174,7 +174,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setName(string $name) : self
+    public function setName(string $name): self
     {
         if (! preg_match($this->nameRegex, $name)) {
             throw new InvalidArgumentException(sprintf(
@@ -192,7 +192,7 @@ class Service
      *
      * @return string
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }
@@ -206,7 +206,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setTransport(string $transport) : self
+    public function setTransport(string $transport): self
     {
         if (! in_array($transport, $this->transportTypes)) {
             throw new InvalidArgumentException(sprintf(
@@ -225,7 +225,7 @@ class Service
      *
      * @return string
      */
-    public function getTransport() : string
+    public function getTransport(): string
     {
         return $this->transport;
     }
@@ -236,7 +236,7 @@ class Service
      * @param  string  $target
      * @return self
      */
-    public function setTarget(string $target) : self
+    public function setTarget(string $target): self
     {
         $this->target = $target;
         return $this;
@@ -247,7 +247,7 @@ class Service
      *
      * @return string
      */
-    public function getTarget() : string
+    public function getTarget(): string
     {
         return $this->target;
     }
@@ -259,7 +259,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setEnvelope(string $envelopeType) : self
+    public function setEnvelope(string $envelopeType): self
     {
         if (! in_array($envelopeType, $this->envelopeTypes)) {
             throw new InvalidArgumentException(sprintf(
@@ -278,7 +278,7 @@ class Service
      *
      * @return string
      */
-    public function getEnvelope() : string
+    public function getEnvelope(): string
     {
         return $this->envelope;
     }
@@ -292,7 +292,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function addParam($type, array $options = [], ?int $order = null) : self
+    public function addParam($type, array $options = [], ?int $order = null): self
     {
         if (! is_string($type) && ! is_array($type)) {
             throw new InvalidArgumentException('Invalid param type provided');
@@ -336,7 +336,7 @@ class Service
      * @param array $params
      * @return self
      */
-    public function addParams(array $params) : self
+    public function addParams(array $params): self
     {
         ksort($params);
 
@@ -363,7 +363,7 @@ class Service
      * @param array $params
      * @return self
      */
-    public function setParams(array $params) : self
+    public function setParams(array $params): self
     {
         $this->params = [];
         return $this->addParams($params);
@@ -376,7 +376,7 @@ class Service
      *
      * @return array
      */
-    public function getParams() : array
+    public function getParams(): array
     {
         $params = [];
         $index  = 0;
@@ -406,7 +406,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setReturn($type) : self
+    public function setReturn($type): self
     {
         if (! is_string($type) && ! is_array($type)) {
             throw new InvalidArgumentException("Invalid param type provided ('" . gettype($type) . "')");
@@ -441,7 +441,7 @@ class Service
      *
      * @return array
      */
-    public function toArray() : array
+    public function toArray(): array
     {
         $envelope   = $this->getEnvelope();
         $target     = $this->getTarget();
@@ -462,7 +462,7 @@ class Service
      *
      * @return string
      */
-    public function toJson() : string
+    public function toJson(): string
     {
         return Json::encode([
             $this->getName() => $this->toArray(),
@@ -474,7 +474,7 @@ class Service
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->toJson();
     }
@@ -487,7 +487,7 @@ class Service
      * @return string
      * @throws InvalidArgumentException
      */
-    protected function validateParamType(string $type, bool $isReturn = false) : string
+    protected function validateParamType(string $type, bool $isReturn = false): string
     {
         if (! is_string($type)) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -150,7 +150,7 @@ class Service
      * @param  array $options
      * @return self
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options) : self
     {
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
@@ -174,7 +174,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setName($name)
+    public function setName($name) : self
     {
         $name = (string) $name;
         if (! preg_match($this->nameRegex, $name)) {
@@ -193,7 +193,7 @@ class Service
      *
      * @return string
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }
@@ -207,7 +207,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setTransport($transport)
+    public function setTransport($transport) : self
     {
         if (! in_array($transport, $this->transportTypes)) {
             throw new InvalidArgumentException(sprintf(
@@ -226,7 +226,7 @@ class Service
      *
      * @return string
      */
-    public function getTransport()
+    public function getTransport() : string
     {
         return $this->transport;
     }
@@ -237,7 +237,7 @@ class Service
      * @param  string  $target
      * @return self
      */
-    public function setTarget($target)
+    public function setTarget($target) : self
     {
         $this->target = (string) $target;
         return $this;
@@ -248,7 +248,7 @@ class Service
      *
      * @return string
      */
-    public function getTarget()
+    public function getTarget() : string
     {
         return $this->target;
     }
@@ -260,7 +260,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setEnvelope($envelopeType)
+    public function setEnvelope($envelopeType) : self
     {
         if (! in_array($envelopeType, $this->envelopeTypes)) {
             throw new InvalidArgumentException(sprintf(
@@ -279,7 +279,7 @@ class Service
      *
      * @return string
      */
-    public function getEnvelope()
+    public function getEnvelope() : string
     {
         return $this->envelope;
     }
@@ -293,7 +293,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function addParam($type, array $options = [], $order = null)
+    public function addParam($type, array $options = [], $order = null) : self
     {
         if (! is_string($type) && ! is_array($type)) {
             throw new InvalidArgumentException('Invalid param type provided');
@@ -337,7 +337,7 @@ class Service
      * @param array $params
      * @return self
      */
-    public function addParams(array $params)
+    public function addParams(array $params) : self
     {
         ksort($params);
 
@@ -364,7 +364,7 @@ class Service
      * @param array $params
      * @return self
      */
-    public function setParams(array $params)
+    public function setParams(array $params) : self
     {
         $this->params = [];
         return $this->addParams($params);
@@ -377,7 +377,7 @@ class Service
      *
      * @return array
      */
-    public function getParams()
+    public function getParams() : array
     {
         $params = [];
         $index  = 0;
@@ -407,7 +407,7 @@ class Service
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setReturn($type)
+    public function setReturn($type) : self
     {
         if (! is_string($type) && ! is_array($type)) {
             throw new InvalidArgumentException("Invalid param type provided ('" . gettype($type) . "')");
@@ -442,7 +442,7 @@ class Service
      *
      * @return array
      */
-    public function toArray()
+    public function toArray() : array
     {
         $envelope   = $this->getEnvelope();
         $target     = $this->getTarget();
@@ -463,7 +463,7 @@ class Service
      *
      * @return string
      */
-    public function toJson()
+    public function toJson() : string
     {
         return Json::encode([
             $this->getName() => $this->toArray(),
@@ -475,7 +475,7 @@ class Service
      *
      * @return string
      */
-    public function __toString()
+    public function __toString() : string
     {
         return $this->toJson();
     }
@@ -488,7 +488,7 @@ class Service
      * @return string
      * @throws InvalidArgumentException
      */
-    protected function validateParamType($type, $isReturn = false)
+    protected function validateParamType($type, $isReturn = false) : string
     {
         if (! is_string($type)) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -14,6 +14,22 @@ use Laminas\Json\Json;
 use Laminas\Json\Server\Exception\InvalidArgumentException;
 use Laminas\Json\Server\Smd;
 
+use function array_key_exists;
+use function array_keys;
+use function array_search;
+use function compact;
+use function get_class_methods;
+use function gettype;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function ksort;
+use function preg_match;
+use function sprintf;
+use function strtolower;
+use function ucfirst;
+
 /**
  * Create Service Mapping Description for a method
  *

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -44,9 +44,9 @@ class Service
      * @var string
      */
     protected $envelope  = Smd::ENV_JSONRPC_1;
-    protected $name;
+    protected $name = '';
     protected $return;
-    protected $target;
+    protected $target = '';
     protected $transport = 'POST';
     /**#@-*/
 
@@ -139,7 +139,7 @@ class Service
             $this->setOptions($spec);
         }
 
-        if (null == $this->getName()) {
+        if ('' == $this->getName()) {
             throw new InvalidArgumentException('SMD service description requires a name; none provided');
         }
     }
@@ -450,7 +450,7 @@ class Service
         $returns    = $this->getReturn();
         $name       = $this->getName();
 
-        if (empty($target)) {
+        if ('' === $target) {
             return compact('envelope', 'transport', 'name', 'parameters', 'returns');
         }
 

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -13,6 +13,12 @@ namespace LaminasTest\Json\Server;
 use Laminas\Json\Server;
 use PHPUnit\Framework\TestCase;
 
+use function file_exists;
+use function is_writable;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
 class CacheTest extends TestCase
 {
     /**

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json\Server;

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -56,17 +56,17 @@ class CacheTest extends TestCase
         }
     }
 
-    public function testRetrievingSmdCacheShouldReturnFalseIfCacheDoesNotExist()
+    public function testRetrievingSmdCacheShouldReturnFalseIfCacheDoesNotExist() : void
     {
         $this->assertFalse(Server\Cache::getSmd($this->cacheFile));
     }
 
-    public function testSavingSmdCacheShouldReturnTrueOnSuccess()
+    public function testSavingSmdCacheShouldReturnTrueOnSuccess() : void
     {
         $this->assertTrue(Server\Cache::saveSmd($this->cacheFile, $this->server));
     }
 
-    public function testSavedCacheShouldMatchGeneratedCache()
+    public function testSavedCacheShouldMatchGeneratedCache() : void
     {
         $this->testSavingSmdCacheShouldReturnTrueOnSuccess();
         $json = $this->server->getServiceMap()->toJSON();
@@ -74,12 +74,12 @@ class CacheTest extends TestCase
         $this->assertSame($json, $test);
     }
 
-    public function testDeletingSmdShouldReturnFalseOnFailure()
+    public function testDeletingSmdShouldReturnFalseOnFailure() : void
     {
         $this->assertFalse(Server\Cache::deleteSmd($this->cacheFile));
     }
 
-    public function testDeletingSmdShouldReturnTrueOnSuccess()
+    public function testDeletingSmdShouldReturnTrueOnSuccess() : void
     {
         $this->testSavingSmdCacheShouldReturnTrueOnSuccess();
         $this->assertTrue(Server\Cache::deleteSmd($this->cacheFile));

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -27,7 +27,7 @@ class CacheTest extends TestCase
      *
      * @return void
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->server = new Server\Server();
         $this->server->setClass(TestAsset\Foo::class, 'foo');
@@ -49,24 +49,24 @@ class CacheTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         if (file_exists($this->cacheFile)) {
             unlink($this->cacheFile);
         }
     }
 
-    public function testRetrievingSmdCacheShouldReturnFalseIfCacheDoesNotExist() : void
+    public function testRetrievingSmdCacheShouldReturnFalseIfCacheDoesNotExist(): void
     {
         $this->assertFalse(Server\Cache::getSmd($this->cacheFile));
     }
 
-    public function testSavingSmdCacheShouldReturnTrueOnSuccess() : void
+    public function testSavingSmdCacheShouldReturnTrueOnSuccess(): void
     {
         $this->assertTrue(Server\Cache::saveSmd($this->cacheFile, $this->server));
     }
 
-    public function testSavedCacheShouldMatchGeneratedCache() : void
+    public function testSavedCacheShouldMatchGeneratedCache(): void
     {
         $this->testSavingSmdCacheShouldReturnTrueOnSuccess();
         $json = $this->server->getServiceMap()->toJSON();
@@ -74,12 +74,12 @@ class CacheTest extends TestCase
         $this->assertSame($json, $test);
     }
 
-    public function testDeletingSmdShouldReturnFalseOnFailure() : void
+    public function testDeletingSmdShouldReturnFalseOnFailure(): void
     {
         $this->assertFalse(Server\Cache::deleteSmd($this->cacheFile));
     }
 
-    public function testDeletingSmdShouldReturnTrueOnSuccess() : void
+    public function testDeletingSmdShouldReturnTrueOnSuccess(): void
     {
         $this->testSavingSmdCacheShouldReturnTrueOnSuccess();
         $this->assertTrue(Server\Cache::deleteSmd($this->cacheFile));

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -282,7 +282,7 @@ class ClientTest extends TestCase
         $this->assertSame('application/jsonrequest', $jsonClient->getHttpClient()->getHeader('Accept'));
     }
 
-    public function getServerResponseFor($nativeVars) : Response
+    public function getServerResponseFor($nativeVars) : string
     {
         $response = new Response();
         $response->setResult($nativeVars);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -93,8 +93,8 @@ class ClientTest extends TestCase
         $this->setServerResponseTo(true);
         $this->jsonClient->call('foo');
 
-        //$this->assertInstanceOf('Laminas\\Json\\Server\\Request', $this->jsonClient->getLastRequest());
-        //$this->assertInstanceOf('Laminas\\Json\\Server\\Response', $this->jsonClient->getLastResponse());
+        $this->assertInstanceOf(Request::class, $this->jsonClient->getLastRequest());
+        $this->assertInstanceOf(Response::class, $this->jsonClient->getLastResponse());
     }
 
     public function testSuccessfulRpcMethodCallWithNoParameters() : void

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -13,12 +13,17 @@ namespace LaminasTest\Json\Server;
 use Laminas\Http\Client\Adapter\Test as TestAdapter;
 use Laminas\Http\Client as HttpClient;
 use Laminas\Http\Response as HttpResponse;
+use Laminas\Json\Json;
 use Laminas\Json\Server\Client;
 use Laminas\Json\Server\Error;
 use Laminas\Json\Server\Exception;
 use Laminas\Json\Server\Request;
 use Laminas\Json\Server\Response;
 use PHPUnit\Framework\TestCase;
+
+use function count;
+use function implode;
+use function strlen;
 
 class ClientTest extends TestCase
 {
@@ -246,7 +251,7 @@ class ClientTest extends TestCase
     {
         $request = new Request();
         $response = new HttpResponse();
-        $response->setContent(\Laminas\Json\Json::encode(['test' => 'test']));
+        $response->setContent(Json::encode(['test' => 'test']));
         $testAdapter = new TestAdapter();
         $testAdapter->setResponse($response);
         $jsonClient = new Client('http://foo');
@@ -260,7 +265,7 @@ class ClientTest extends TestCase
     {
         $request = new Request();
         $response = new HttpResponse();
-        $response->setContent(\Laminas\Json\Json::encode(['test' => 'test']));
+        $response->setContent(Json::encode(['test' => 'test']));
         $testAdapter = new TestAdapter();
         $testAdapter->setResponse($response);
 
@@ -306,7 +311,7 @@ class ClientTest extends TestCase
 
     public function mockHttpClient()
     {
-        $this->mockedHttpClient = $this->getMock('Laminas\\Http\\Client');
+        $this->mockedHttpClient = $this->getMock(HttpClient::class);
         $this->jsonClient->setHttpClient($this->mockedHttpClient);
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -187,7 +187,7 @@ class ClientTest extends TestCase
         $this->jsonClient->call('foo');
         $uri = $this->jsonClient->getHttpClient()->getUri()->toString();
 
-        $this->assertEquals($changedUri, $uri);
+        $this->assertSame($changedUri, $uri);
     }
 
     public function testSettingNoHttpClientUriForcesClientToSetUri(): void
@@ -204,7 +204,7 @@ class ClientTest extends TestCase
         $this->jsonClient->call('foo');
         $uri = $this->jsonClient->getHttpClient()->getUri();
 
-        $this->assertEquals($baseUri, $uri->toString());
+        $this->assertSame($baseUri, $uri->toString());
     }
 
     public function testCustomHttpClientUserAgentIsNotOverridden(): void

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Http\Client\Adapter\Test as TestAdapter;

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
 
     // HTTP Client
 
-    public function testGettingDefaultHttpClient()
+    public function testGettingDefaultHttpClient() : void
     {
         $jsonClient = new Client('http://foo');
         $httpClient = $jsonClient->getHttpClient();
@@ -64,7 +64,7 @@ class ClientTest extends TestCase
         $this->assertSame($httpClient, $jsonClient->getHttpClient());
     }
 
-    public function testSettingAndGettingHttpClient()
+    public function testSettingAndGettingHttpClient() : void
     {
         $jsonClient = new Client('http://foo');
         $this->assertNotSame($this->httpClient, $jsonClient->getHttpClient());
@@ -73,7 +73,7 @@ class ClientTest extends TestCase
         $this->assertSame($this->httpClient, $jsonClient->getHttpClient());
     }
 
-    public function testSettingHttpClientViaConstructor()
+    public function testSettingHttpClientViaConstructor() : void
     {
         $jsonClient = new Client('http://foo', $this->httpClient);
         $httpClient   = $jsonClient->getHttpClient();
@@ -82,13 +82,13 @@ class ClientTest extends TestCase
 
     // Request & Response
 
-    public function testLastRequestAndResponseAreInitiallyNull()
+    public function testLastRequestAndResponseAreInitiallyNull() : void
     {
         $this->assertNull($this->jsonClient->getLastRequest());
         $this->assertNull($this->jsonClient->getLastResponse());
     }
 
-    public function testLastRequestAndResponseAreSetAfterRpcMethodCall()
+    public function testLastRequestAndResponseAreSetAfterRpcMethodCall() : void
     {
         $this->setServerResponseTo(true);
         $this->jsonClient->call('foo');
@@ -97,7 +97,7 @@ class ClientTest extends TestCase
         //$this->assertInstanceOf('Laminas\\Json\\Server\\Response', $this->jsonClient->getLastResponse());
     }
 
-    public function testSuccessfulRpcMethodCallWithNoParameters()
+    public function testSuccessfulRpcMethodCallWithNoParameters() : void
     {
         $expectedMethod = 'foo';
         $expectedReturn = 7;
@@ -114,7 +114,7 @@ class ClientTest extends TestCase
         $this->assertFalse($response->isError());
     }
 
-    public function testSuccessfulRpcMethodCallWithParameters()
+    public function testSuccessfulRpcMethodCallWithParameters() : void
     {
         $expectedMethod = 'foobar';
         $expectedParams = [1, 1.1, true, 'foo' => 'bar'];
@@ -142,7 +142,7 @@ class ClientTest extends TestCase
 
     // Faults
 
-    public function testRpcMethodCallThrowsOnHttpFailure()
+    public function testRpcMethodCallThrowsOnHttpFailure() : void
     {
         $status  = 404;
         $message = 'Not Found';
@@ -157,7 +157,7 @@ class ClientTest extends TestCase
         $this->jsonClient->call('foo');
     }
 
-    public function testRpcMethodCallThrowsOnJsonRpcFault()
+    public function testRpcMethodCallThrowsOnJsonRpcFault() : void
     {
         $code = -32050;
         $message = 'foo';
@@ -178,7 +178,7 @@ class ClientTest extends TestCase
 
     // HTTP handling
 
-    public function testSettingUriOnHttpClientIsNotOverwrittenByJsonRpcClient()
+    public function testSettingUriOnHttpClientIsNotOverwrittenByJsonRpcClient() : void
     {
         $changedUri = 'http://bar:80/';
         // Overwrite: http://foo:80
@@ -190,7 +190,7 @@ class ClientTest extends TestCase
         $this->assertEquals($changedUri, $uri);
     }
 
-    public function testSettingNoHttpClientUriForcesClientToSetUri()
+    public function testSettingNoHttpClientUriForcesClientToSetUri() : void
     {
         $baseUri = 'http://foo:80/';
         $this->httpAdapter = new TestAdapter();
@@ -207,7 +207,7 @@ class ClientTest extends TestCase
         $this->assertEquals($baseUri, $uri->toString());
     }
 
-    public function testCustomHttpClientUserAgentIsNotOverridden()
+    public function testCustomHttpClientUserAgentIsNotOverridden() : void
     {
         $this->assertFalse(
             $this->httpClient->getHeader('User-Agent'),
@@ -232,7 +232,7 @@ class ClientTest extends TestCase
     /**
      * @group 5956
      */
-    public function testScalarServerResponseThrowsException()
+    public function testScalarServerResponseThrowsException() : void
     {
         $response = $this->makeHttpResponseFrom('false');
         $this->httpAdapter->setResponse($response);
@@ -241,13 +241,13 @@ class ClientTest extends TestCase
     }
 
     // Helpers
-    public function setServerResponseTo($nativeVars)
+    public function setServerResponseTo($nativeVars) : void
     {
         $response = $this->getServerResponseFor($nativeVars);
         $this->httpAdapter->setResponse($response);
     }
 
-    public function testClientShouldSetDefaultAcceptAndContentTypeHeadersOnRequest()
+    public function testClientShouldSetDefaultAcceptAndContentTypeHeadersOnRequest() : void
     {
         $request = new Request();
         $response = new HttpResponse();
@@ -261,7 +261,7 @@ class ClientTest extends TestCase
         $this->assertSame('application/json-rpc', $jsonClient->getHttpClient()->getHeader('Accept'));
     }
 
-    public function testClientShouldNotOverwriteAcceptAndContentTypeHeadersIfAlreadyPresentInRequest()
+    public function testClientShouldNotOverwriteAcceptAndContentTypeHeadersIfAlreadyPresentInRequest() : void
     {
         $request = new Request();
         $response = new HttpResponse();
@@ -282,7 +282,7 @@ class ClientTest extends TestCase
         $this->assertSame('application/jsonrequest', $jsonClient->getHttpClient()->getHeader('Accept'));
     }
 
-    public function getServerResponseFor($nativeVars)
+    public function getServerResponseFor($nativeVars) : Response
     {
         $response = new Response();
         $response->setResult($nativeVars);
@@ -292,7 +292,7 @@ class ClientTest extends TestCase
         return $response;
     }
 
-    public function makeHttpResponseFrom($data, $status = 200, $message = 'OK')
+    public function makeHttpResponseFrom($data, $status = 200, $message = 'OK') : string
     {
         $headers = [
             "HTTP/1.1 $status $message",
@@ -303,13 +303,13 @@ class ClientTest extends TestCase
         return implode("\r\n", $headers) . "\r\n\r\n$data\r\n\r\n";
     }
 
-    public function makeHttpResponseFor($nativeVars)
+    public function makeHttpResponseFor($nativeVars) : HttpResponse
     {
         $response = $this->getServerResponseFor($nativeVars);
         return HttpResponse::fromString($response);
     }
 
-    public function mockHttpClient()
+    public function mockHttpClient() : void
     {
         $this->mockedHttpClient = $this->getMock(HttpClient::class);
         $this->jsonClient->setHttpClient($this->mockedHttpClient);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -42,7 +42,7 @@ class ClientTest extends TestCase
      */
     protected $jsonClient;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->httpAdapter = new TestAdapter();
         $this->httpClient = new HttpClient(
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
 
     // HTTP Client
 
-    public function testGettingDefaultHttpClient() : void
+    public function testGettingDefaultHttpClient(): void
     {
         $jsonClient = new Client('http://foo');
         $httpClient = $jsonClient->getHttpClient();
@@ -64,7 +64,7 @@ class ClientTest extends TestCase
         $this->assertSame($httpClient, $jsonClient->getHttpClient());
     }
 
-    public function testSettingAndGettingHttpClient() : void
+    public function testSettingAndGettingHttpClient(): void
     {
         $jsonClient = new Client('http://foo');
         $this->assertNotSame($this->httpClient, $jsonClient->getHttpClient());
@@ -73,7 +73,7 @@ class ClientTest extends TestCase
         $this->assertSame($this->httpClient, $jsonClient->getHttpClient());
     }
 
-    public function testSettingHttpClientViaConstructor() : void
+    public function testSettingHttpClientViaConstructor(): void
     {
         $jsonClient = new Client('http://foo', $this->httpClient);
         $httpClient   = $jsonClient->getHttpClient();
@@ -82,13 +82,13 @@ class ClientTest extends TestCase
 
     // Request & Response
 
-    public function testLastRequestAndResponseAreInitiallyNull() : void
+    public function testLastRequestAndResponseAreInitiallyNull(): void
     {
         $this->assertNull($this->jsonClient->getLastRequest());
         $this->assertNull($this->jsonClient->getLastResponse());
     }
 
-    public function testLastRequestAndResponseAreSetAfterRpcMethodCall() : void
+    public function testLastRequestAndResponseAreSetAfterRpcMethodCall(): void
     {
         $this->setServerResponseTo(true);
         $this->jsonClient->call('foo');
@@ -97,7 +97,7 @@ class ClientTest extends TestCase
         $this->assertInstanceOf(Response::class, $this->jsonClient->getLastResponse());
     }
 
-    public function testSuccessfulRpcMethodCallWithNoParameters() : void
+    public function testSuccessfulRpcMethodCallWithNoParameters(): void
     {
         $expectedMethod = 'foo';
         $expectedReturn = 7;
@@ -114,7 +114,7 @@ class ClientTest extends TestCase
         $this->assertFalse($response->isError());
     }
 
-    public function testSuccessfulRpcMethodCallWithParameters() : void
+    public function testSuccessfulRpcMethodCallWithParameters(): void
     {
         $expectedMethod = 'foobar';
         $expectedParams = [1, 1.1, true, 'foo' => 'bar'];
@@ -142,7 +142,7 @@ class ClientTest extends TestCase
 
     // Faults
 
-    public function testRpcMethodCallThrowsOnHttpFailure() : void
+    public function testRpcMethodCallThrowsOnHttpFailure(): void
     {
         $status  = 404;
         $message = 'Not Found';
@@ -157,7 +157,7 @@ class ClientTest extends TestCase
         $this->jsonClient->call('foo');
     }
 
-    public function testRpcMethodCallThrowsOnJsonRpcFault() : void
+    public function testRpcMethodCallThrowsOnJsonRpcFault(): void
     {
         $code = -32050;
         $message = 'foo';
@@ -178,7 +178,7 @@ class ClientTest extends TestCase
 
     // HTTP handling
 
-    public function testSettingUriOnHttpClientIsNotOverwrittenByJsonRpcClient() : void
+    public function testSettingUriOnHttpClientIsNotOverwrittenByJsonRpcClient(): void
     {
         $changedUri = 'http://bar:80/';
         // Overwrite: http://foo:80
@@ -190,7 +190,7 @@ class ClientTest extends TestCase
         $this->assertEquals($changedUri, $uri);
     }
 
-    public function testSettingNoHttpClientUriForcesClientToSetUri() : void
+    public function testSettingNoHttpClientUriForcesClientToSetUri(): void
     {
         $baseUri = 'http://foo:80/';
         $this->httpAdapter = new TestAdapter();
@@ -207,7 +207,7 @@ class ClientTest extends TestCase
         $this->assertEquals($baseUri, $uri->toString());
     }
 
-    public function testCustomHttpClientUserAgentIsNotOverridden() : void
+    public function testCustomHttpClientUserAgentIsNotOverridden(): void
     {
         $this->assertFalse(
             $this->httpClient->getHeader('User-Agent'),
@@ -232,7 +232,7 @@ class ClientTest extends TestCase
     /**
      * @group 5956
      */
-    public function testScalarServerResponseThrowsException() : void
+    public function testScalarServerResponseThrowsException(): void
     {
         $response = $this->makeHttpResponseFrom('false');
         $this->httpAdapter->setResponse($response);
@@ -241,13 +241,13 @@ class ClientTest extends TestCase
     }
 
     // Helpers
-    public function setServerResponseTo($nativeVars) : void
+    public function setServerResponseTo($nativeVars): void
     {
         $response = $this->getServerResponseFor($nativeVars);
         $this->httpAdapter->setResponse($response);
     }
 
-    public function testClientShouldSetDefaultAcceptAndContentTypeHeadersOnRequest() : void
+    public function testClientShouldSetDefaultAcceptAndContentTypeHeadersOnRequest(): void
     {
         $request = new Request();
         $response = new HttpResponse();
@@ -261,7 +261,7 @@ class ClientTest extends TestCase
         $this->assertSame('application/json-rpc', $jsonClient->getHttpClient()->getHeader('Accept'));
     }
 
-    public function testClientShouldNotOverwriteAcceptAndContentTypeHeadersIfAlreadyPresentInRequest() : void
+    public function testClientShouldNotOverwriteAcceptAndContentTypeHeadersIfAlreadyPresentInRequest(): void
     {
         $request = new Request();
         $response = new HttpResponse();
@@ -282,7 +282,7 @@ class ClientTest extends TestCase
         $this->assertSame('application/jsonrequest', $jsonClient->getHttpClient()->getHeader('Accept'));
     }
 
-    public function getServerResponseFor($nativeVars) : string
+    public function getServerResponseFor($nativeVars): string
     {
         $response = new Response();
         $response->setResult($nativeVars);
@@ -292,7 +292,7 @@ class ClientTest extends TestCase
         return $response;
     }
 
-    public function makeHttpResponseFrom($data, $status = 200, $message = 'OK') : string
+    public function makeHttpResponseFrom($data, $status = 200, $message = 'OK'): string
     {
         $headers = [
             "HTTP/1.1 $status $message",
@@ -303,13 +303,13 @@ class ClientTest extends TestCase
         return implode("\r\n", $headers) . "\r\n\r\n$data\r\n\r\n";
     }
 
-    public function makeHttpResponseFor($nativeVars) : HttpResponse
+    public function makeHttpResponseFor($nativeVars): HttpResponse
     {
         $response = $this->getServerResponseFor($nativeVars);
         return HttpResponse::fromString($response);
     }
 
-    public function mockHttpClient() : void
+    public function mockHttpClient(): void
     {
         $this->mockedHttpClient = $this->getMock(HttpClient::class);
         $this->jsonClient->setHttpClient($this->mockedHttpClient);

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -32,14 +32,14 @@ class ErrorTest extends TestCase
 
     public function testCodeShouldBeErrOtherByDefault(): void
     {
-        $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
+        $this->assertSame(Server\Error::ERROR_OTHER, $this->error->getCode());
     }
 
     public function testCodeShouldAllowArbitraryAppErrorCodesInXmlRpcErrorCodeRange(): void
     {
         foreach (range(-32099, -32000) as $code) {
             $this->error->setCode($code);
-            $this->assertEquals($code, $this->error->getCode());
+            $this->assertSame($code, $this->error->getCode());
         }
     }
 
@@ -58,12 +58,12 @@ class ErrorTest extends TestCase
     public function testCodeShouldAllowArbitraryErrorCode(int $code): void
     {
         $this->error->setCode($code);
-        $this->assertEquals($code, $this->error->getCode());
+        $this->assertSame($code, $this->error->getCode());
     }
 
     public function testMessageShouldBeAnEmptyStringByDefault(): void
     {
-        $this->assertEquals('', $this->error->getMessage());
+        $this->assertSame('', $this->error->getMessage());
     }
 
     public function testDataShouldBeNullByDefault(): void
@@ -75,7 +75,7 @@ class ErrorTest extends TestCase
     {
         foreach ([true, 'foo', 2, 2.0, [], new stdClass()] as $datum) {
             $this->error->setData($datum);
-            $this->assertEquals($datum, $this->error->getData());
+            $this->assertSame($datum, $this->error->getData());
         }
     }
 
@@ -118,8 +118,8 @@ class ErrorTest extends TestCase
         $this->assertIsString($error['message']);
         $this->assertIsArray($error['data']);
 
-        $this->assertEquals($this->error->getCode(), $error['code']);
-        $this->assertEquals($this->error->getMessage(), $error['message']);
+        $this->assertSame($this->error->getCode(), $error['code']);
+        $this->assertSame($this->error->getMessage(), $error['message']);
         $this->assertSame($this->error->getData(), $error['data']);
     }
 }

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -69,7 +69,7 @@ class ErrorTest extends TestCase
     /**
      * @dataProvider arbitraryErrorCodes
      */
-    public function testCodeShouldAllowArbitraryErrorCode($code) : void
+    public function testCodeShouldAllowArbitraryErrorCode(int $code) : void
     {
         $this->error->setCode($code);
         $this->assertEquals($code, $this->error->getCode());
@@ -137,7 +137,7 @@ class ErrorTest extends TestCase
                     ->setData(['foo' => 'bar']);
     }
 
-    public function validateArray($error) : void
+    public function validateArray(array $error) : void
     {
         $this->assertIsArray($error);
         $this->assertArrayHasKey('code', $error);

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -30,18 +30,18 @@ class ErrorTest extends TestCase
         $this->error = new Server\Error();
     }
 
-    public function testCodeShouldBeErrOtherByDefault()
+    public function testCodeShouldBeErrOtherByDefault() : void
     {
         $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
     }
 
-    public function testSetCodeShouldCastToInteger()
+    public function testSetCodeShouldCastToInteger() : void
     {
         $this->error->setCode('-32700');
         $this->assertEquals(-32700, $this->error->getCode());
     }
 
-    public function testCodeShouldBeLimitedToStandardIntegers()
+    public function testCodeShouldBeLimitedToStandardIntegers() : void
     {
         foreach ([null, true, 'foo', [], new stdClass(), 2.0] as $code) {
             $this->error->setCode($code);
@@ -49,7 +49,7 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function testCodeShouldAllowArbitraryAppErrorCodesInXmlRpcErrorCodeRange()
+    public function testCodeShouldAllowArbitraryAppErrorCodesInXmlRpcErrorCodeRange() : void
     {
         foreach (range(-32099, -32000) as $code) {
             $this->error->setCode($code);
@@ -57,7 +57,7 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function arbitraryErrorCodes()
+    public function arbitraryErrorCodes() : array
     {
         return [
             '1000'  => [1000],
@@ -69,18 +69,18 @@ class ErrorTest extends TestCase
     /**
      * @dataProvider arbitraryErrorCodes
      */
-    public function testCodeShouldAllowArbitraryErrorCode($code)
+    public function testCodeShouldAllowArbitraryErrorCode($code) : void
     {
         $this->error->setCode($code);
         $this->assertEquals($code, $this->error->getCode());
     }
 
-    public function testMessageShouldBeNullByDefault()
+    public function testMessageShouldBeNullByDefault() : void
     {
         $this->assertNull($this->error->getMessage());
     }
 
-    public function testSetMessageShouldCastToString()
+    public function testSetMessageShouldCastToString() : void
     {
         foreach ([true, 2.0, 25] as $message) {
             $this->error->setMessage($message);
@@ -88,7 +88,7 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function testSetMessageToNonScalarShouldSilentlyFail()
+    public function testSetMessageToNonScalarShouldSilentlyFail() : void
     {
         foreach ([[], new stdClass()] as $message) {
             $this->error->setMessage($message);
@@ -96,12 +96,12 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function testDataShouldBeNullByDefault()
+    public function testDataShouldBeNullByDefault() : void
     {
         $this->assertNull($this->error->getData());
     }
 
-    public function testShouldAllowArbitraryData()
+    public function testShouldAllowArbitraryData() : void
     {
         foreach ([true, 'foo', 2, 2.0, [], new stdClass()] as $datum) {
             $this->error->setData($datum);
@@ -109,35 +109,35 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToCastToArray()
+    public function testShouldBeAbleToCastToArray() : void
     {
         $this->setupError();
         $array = $this->error->toArray();
         $this->validateArray($array);
     }
 
-    public function testShouldBeAbleToCastToJSON()
+    public function testShouldBeAbleToCastToJSON() : void
     {
         $this->setupError();
         $json = $this->error->toJSON();
         $this->validateArray(Json\Json::decode($json, Json\Json::TYPE_ARRAY));
     }
 
-    public function testCastingToStringShouldCastToJSON()
+    public function testCastingToStringShouldCastToJSON() : void
     {
         $this->setupError();
         $json = $this->error->__toString();
         $this->validateArray(Json\Json::decode($json, Json\Json::TYPE_ARRAY));
     }
 
-    public function setupError()
+    public function setupError() : void
     {
         $this->error->setCode(Server\Error::ERROR_OTHER)
                     ->setMessage('Unknown Error')
                     ->setData(['foo' => 'bar']);
     }
 
-    public function validateArray($error)
+    public function validateArray($error) : void
     {
         $this->assertIsArray($error);
         $this->assertArrayHasKey('code', $error);

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json;

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -13,6 +13,9 @@ namespace LaminasTest\Json\Server;
 use Laminas\Json;
 use Laminas\Json\Server;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function range;
 
 class ErrorTest extends TestCase
 {
@@ -40,7 +43,7 @@ class ErrorTest extends TestCase
 
     public function testCodeShouldBeLimitedToStandardIntegers()
     {
-        foreach ([null, true, 'foo', [], new \stdClass, 2.0] as $code) {
+        foreach ([null, true, 'foo', [], new stdClass(), 2.0] as $code) {
             $this->error->setCode($code);
             $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
         }
@@ -87,7 +90,7 @@ class ErrorTest extends TestCase
 
     public function testSetMessageToNonScalarShouldSilentlyFail()
     {
-        foreach ([[], new \stdClass] as $message) {
+        foreach ([[], new stdClass()] as $message) {
             $this->error->setMessage($message);
             $this->assertNull($this->error->getMessage());
         }
@@ -100,7 +103,7 @@ class ErrorTest extends TestCase
 
     public function testShouldAllowArbitraryData()
     {
-        foreach ([true, 'foo', 2, 2.0, [], new \stdClass] as $datum) {
+        foreach ([true, 'foo', 2, 2.0, [], new stdClass()] as $datum) {
             $this->error->setData($datum);
             $this->assertEquals($datum, $this->error->getData());
         }

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -25,17 +25,17 @@ class ErrorTest extends TestCase
      *
      * @return void
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->error = new Server\Error();
     }
 
-    public function testCodeShouldBeErrOtherByDefault() : void
+    public function testCodeShouldBeErrOtherByDefault(): void
     {
         $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
     }
 
-    public function testCodeShouldAllowArbitraryAppErrorCodesInXmlRpcErrorCodeRange() : void
+    public function testCodeShouldAllowArbitraryAppErrorCodesInXmlRpcErrorCodeRange(): void
     {
         foreach (range(-32099, -32000) as $code) {
             $this->error->setCode($code);
@@ -43,7 +43,7 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function arbitraryErrorCodes() : array
+    public function arbitraryErrorCodes(): array
     {
         return [
             '1000'  => [1000],
@@ -55,23 +55,23 @@ class ErrorTest extends TestCase
     /**
      * @dataProvider arbitraryErrorCodes
      */
-    public function testCodeShouldAllowArbitraryErrorCode(int $code) : void
+    public function testCodeShouldAllowArbitraryErrorCode(int $code): void
     {
         $this->error->setCode($code);
         $this->assertEquals($code, $this->error->getCode());
     }
 
-    public function testMessageShouldBeAnEmptyStringByDefault() : void
+    public function testMessageShouldBeAnEmptyStringByDefault(): void
     {
         $this->assertEquals('', $this->error->getMessage());
     }
 
-    public function testDataShouldBeNullByDefault() : void
+    public function testDataShouldBeNullByDefault(): void
     {
         $this->assertNull($this->error->getData());
     }
 
-    public function testShouldAllowArbitraryData() : void
+    public function testShouldAllowArbitraryData(): void
     {
         foreach ([true, 'foo', 2, 2.0, [], new stdClass()] as $datum) {
             $this->error->setData($datum);
@@ -79,35 +79,35 @@ class ErrorTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToCastToArray() : void
+    public function testShouldBeAbleToCastToArray(): void
     {
         $this->setupError();
         $array = $this->error->toArray();
         $this->validateArray($array);
     }
 
-    public function testShouldBeAbleToCastToJSON() : void
+    public function testShouldBeAbleToCastToJSON(): void
     {
         $this->setupError();
         $json = $this->error->toJSON();
         $this->validateArray(Json\Json::decode($json, Json\Json::TYPE_ARRAY));
     }
 
-    public function testCastingToStringShouldCastToJSON() : void
+    public function testCastingToStringShouldCastToJSON(): void
     {
         $this->setupError();
         $json = $this->error->__toString();
         $this->validateArray(Json\Json::decode($json, Json\Json::TYPE_ARRAY));
     }
 
-    public function setupError() : void
+    public function setupError(): void
     {
         $this->error->setCode(Server\Error::ERROR_OTHER)
                     ->setMessage('Unknown Error')
                     ->setData(['foo' => 'bar']);
     }
 
-    public function validateArray(array $error) : void
+    public function validateArray(array $error): void
     {
         $this->assertIsArray($error);
         $this->assertArrayHasKey('code', $error);

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -35,20 +35,6 @@ class ErrorTest extends TestCase
         $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
     }
 
-    public function testSetCodeShouldCastToInteger() : void
-    {
-        $this->error->setCode('-32700');
-        $this->assertEquals(-32700, $this->error->getCode());
-    }
-
-    public function testCodeShouldBeLimitedToStandardIntegers() : void
-    {
-        foreach ([null, true, 'foo', [], new stdClass(), 2.0] as $code) {
-            $this->error->setCode($code);
-            $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
-        }
-    }
-
     public function testCodeShouldAllowArbitraryAppErrorCodesInXmlRpcErrorCodeRange() : void
     {
         foreach (range(-32099, -32000) as $code) {
@@ -75,25 +61,9 @@ class ErrorTest extends TestCase
         $this->assertEquals($code, $this->error->getCode());
     }
 
-    public function testMessageShouldBeNullByDefault() : void
+    public function testMessageShouldBeAnEmptyStringByDefault() : void
     {
-        $this->assertNull($this->error->getMessage());
-    }
-
-    public function testSetMessageShouldCastToString() : void
-    {
-        foreach ([true, 2.0, 25] as $message) {
-            $this->error->setMessage($message);
-            $this->assertEquals((string) $message, $this->error->getMessage());
-        }
-    }
-
-    public function testSetMessageToNonScalarShouldSilentlyFail() : void
-    {
-        foreach ([[], new stdClass()] as $message) {
-            $this->error->setMessage($message);
-            $this->assertNull($this->error->getMessage());
-        }
+        $this->assertEquals('', $this->error->getMessage());
     }
 
     public function testDataShouldBeNullByDefault() : void

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -44,7 +44,7 @@ class RequestTest extends TestCase
         $params = $this->request->getParams();
         $this->assertCount(1, $params);
         $test = array_shift($params);
-        $this->assertEquals('foo', $test);
+        $this->assertSame('foo', $test);
     }
 
     public function testShouldBeAbleToAddAParamAsKeyValuePair(): void
@@ -53,7 +53,7 @@ class RequestTest extends TestCase
         $params = $this->request->getParams();
         $this->assertCount(1, $params);
         $this->assertArrayHasKey('foo', $params);
-        $this->assertEquals('bar', $params['foo']);
+        $this->assertSame('bar', $params['foo']);
     }
 
     public function testInvalidKeysShouldBeIgnored(): void
@@ -101,7 +101,7 @@ class RequestTest extends TestCase
         ];
         $this->request->addParams($params);
         $test = $this->request->getParams();
-        $this->assertEquals(array_values($params), array_values($test));
+        $this->assertSame(array_values($params), array_values($test));
         $this->assertArrayHasKey('foo', $test);
         $this->assertArrayHasKey('baz', $test);
         $this->assertContains('baz', $test);
@@ -123,14 +123,14 @@ class RequestTest extends TestCase
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = $this->request->getParams();
-        $this->assertEquals('bar', $this->request->getParam('foo'), var_export($params, true));
-        $this->assertEquals('baz', $this->request->getParam(1), var_export($params, true));
-        $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, true));
+        $this->assertSame('bar', $this->request->getParam('foo'), var_export($params, true));
+        $this->assertSame('baz', $this->request->getParam(1), var_export($params, true));
+        $this->assertSame('bat', $this->request->getParam('baz'), var_export($params, true));
     }
 
     public function testMethodShouldBeAnEmptyStringByDefault(): void
     {
-        $this->assertEquals('', $this->request->getMethod());
+        $this->assertSame('', $this->request->getMethod());
     }
 
     public function testMethodErrorShouldBeFalseByDefault(): void
@@ -141,14 +141,14 @@ class RequestTest extends TestCase
     public function testMethodAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->request->setMethod('foo');
-        $this->assertEquals('foo', $this->request->getMethod());
+        $this->assertSame('foo', $this->request->getMethod());
     }
 
     public function testSettingMethodWithInvalidNameShouldSetError(): void
     {
         foreach (['1ad', 'abc-123', 'ad$$832r#@'] as $method) {
             $this->request->setMethod($method);
-            $this->assertEquals('', $this->request->getMethod());
+            $this->assertSame('', $this->request->getMethod());
             $this->assertTrue($this->request->isMethodError());
         }
     }
@@ -161,21 +161,21 @@ class RequestTest extends TestCase
     public function testIdAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->request->setId('foo');
-        $this->assertEquals('foo', $this->request->getId());
+        $this->assertSame('foo', $this->request->getId());
     }
 
     public function testVersionShouldBeJSONRpcV1ByDefault(): void
     {
-        $this->assertEquals('1.0', $this->request->getVersion());
+        $this->assertSame('1.0', $this->request->getVersion());
     }
 
     public function testVersionShouldBeLimitedToV1AndV2(): void
     {
         $this->testVersionShouldBeJSONRpcV1ByDefault();
         $this->request->setVersion('2.0');
-        $this->assertEquals('2.0', $this->request->getVersion());
+        $this->assertSame('2.0', $this->request->getVersion());
         $this->request->setVersion('foo');
-        $this->assertEquals('1.0', $this->request->getVersion());
+        $this->assertSame('1.0', $this->request->getVersion());
     }
 
     public function testShouldBeAbleToLoadRequestFromJSONString(): void
@@ -184,9 +184,9 @@ class RequestTest extends TestCase
         $json    = Json::encode($options);
         $this->request->loadJSON($json);
 
-        $this->assertEquals('foo', $this->request->getMethod());
-        $this->assertEquals('foobar', $this->request->getId());
-        $this->assertEquals($options['params'], $this->request->getParams());
+        $this->assertSame('foo', $this->request->getMethod());
+        $this->assertSame('foobar', $this->request->getId());
+        $this->assertSame($options['params'], $this->request->getParams());
     }
 
     public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
@@ -195,7 +195,7 @@ class RequestTest extends TestCase
         $options['jsonrpc'] = '2.0';
         $json    = Json::encode($options);
         $this->request->loadJSON($json);
-        $this->assertEquals('2.0', $this->request->getVersion());
+        $this->assertSame('2.0', $this->request->getVersion());
     }
 
     public function testShouldBeAbleToCastToJSON(): void
@@ -220,7 +220,7 @@ class RequestTest extends TestCase
     public function testMethodNamesShouldAllowDotNamespacing(): void
     {
         $this->request->setMethod('foo.bar');
-        $this->assertEquals('foo.bar', $this->request->getMethod());
+        $this->assertSame('foo.bar', $this->request->getMethod());
     }
 
     public function testIsParseErrorSetOnMalformedJson(): void
@@ -256,8 +256,8 @@ class RequestTest extends TestCase
         $this->assertIsString($test['method']);
         $this->assertIsArray($test['params']);
 
-        $this->assertEquals($options['id'], $test['id']);
-        $this->assertEquals($options['method'], $test['method']);
+        $this->assertSame($options['id'], $test['id']);
+        $this->assertSame($options['method'], $test['method']);
         $this->assertSame($options['params'], $test['params']);
     }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json\Json;

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -123,14 +123,14 @@ class RequestTest extends TestCase
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = $this->request->getParams();
-        $this->assertEquals('bar', $this->request->getParam('foo'), var_export($params, 1));
-        $this->assertEquals('baz', $this->request->getParam(1), var_export($params, 1));
-        $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, 1));
+        $this->assertEquals('bar', $this->request->getParam('foo'), var_export($params, true));
+        $this->assertEquals('baz', $this->request->getParam(1), var_export($params, true));
+        $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, true));
     }
 
-    public function testMethodShouldBeNullByDefault() : void
+    public function testMethodShouldBeAnEmptyStringByDefault() : void
     {
-        $this->assertNull($this->request->getMethod());
+        $this->assertEquals('', $this->request->getMethod());
     }
 
     public function testMethodErrorShouldBeFalseByDefault() : void
@@ -148,7 +148,7 @@ class RequestTest extends TestCase
     {
         foreach (['1ad', 'abc-123', 'ad$$832r#@'] as $method) {
             $this->request->setMethod($method);
-            $this->assertNull($this->request->getMethod());
+            $this->assertEquals('', $this->request->getMethod());
             $this->assertTrue($this->request->isMethodError());
         }
     }
@@ -246,7 +246,7 @@ class RequestTest extends TestCase
     public function validateJSON(string $json, array $options) : void
     {
         $test = Json::decode($json, Json::TYPE_ARRAY);
-        $this->assertIsArray($test, var_export($json, 1));
+        $this->assertIsArray($test, var_export($json, true));
 
         $this->assertArrayHasKey('id', $test);
         $this->assertArrayHasKey('method', $test);

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -27,18 +27,18 @@ class RequestTest extends TestCase
      *
      * @return void
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->request = new Request();
     }
 
-    public function testShouldHaveNoParamsByDefault() : void
+    public function testShouldHaveNoParamsByDefault(): void
     {
         $params = $this->request->getParams();
         $this->assertEmpty($params);
     }
 
-    public function testShouldBeAbleToAddAParamAsValueOnly() : void
+    public function testShouldBeAbleToAddAParamAsValueOnly(): void
     {
         $this->request->addParam('foo');
         $params = $this->request->getParams();
@@ -47,7 +47,7 @@ class RequestTest extends TestCase
         $this->assertEquals('foo', $test);
     }
 
-    public function testShouldBeAbleToAddAParamAsKeyValuePair() : void
+    public function testShouldBeAbleToAddAParamAsKeyValuePair(): void
     {
         $this->request->addParam('bar', 'foo');
         $params = $this->request->getParams();
@@ -56,7 +56,7 @@ class RequestTest extends TestCase
         $this->assertEquals('bar', $params['foo']);
     }
 
-    public function testInvalidKeysShouldBeIgnored() : void
+    public function testInvalidKeysShouldBeIgnored(): void
     {
         $count = 0;
         foreach ([['foo', true], ['foo', new stdClass()], ['foo', []]] as $spec) {
@@ -68,7 +68,7 @@ class RequestTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToAddMultipleIndexedParamsAtOnce() : void
+    public function testShouldBeAbleToAddMultipleIndexedParamsAtOnce(): void
     {
         $params = [
             'foo',
@@ -80,7 +80,7 @@ class RequestTest extends TestCase
         $this->assertSame($params, $test);
     }
 
-    public function testShouldBeAbleToAddMultipleNamedParamsAtOnce() : void
+    public function testShouldBeAbleToAddMultipleNamedParamsAtOnce(): void
     {
         $params = [
             'foo' => 'bar',
@@ -92,7 +92,7 @@ class RequestTest extends TestCase
         $this->assertSame($params, $test);
     }
 
-    public function testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce() : void
+    public function testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce(): void
     {
         $params = [
             'foo' => 'bar',
@@ -107,7 +107,7 @@ class RequestTest extends TestCase
         $this->assertContains('baz', $test);
     }
 
-    public function testSetParamsShouldOverwriteParams() : void
+    public function testSetParamsShouldOverwriteParams(): void
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = [
@@ -119,7 +119,7 @@ class RequestTest extends TestCase
         $this->assertSame($params, $this->request->getParams());
     }
 
-    public function testShouldBeAbleToRetrieveParamByKeyOrIndex() : void
+    public function testShouldBeAbleToRetrieveParamByKeyOrIndex(): void
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = $this->request->getParams();
@@ -128,23 +128,23 @@ class RequestTest extends TestCase
         $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, true));
     }
 
-    public function testMethodShouldBeAnEmptyStringByDefault() : void
+    public function testMethodShouldBeAnEmptyStringByDefault(): void
     {
         $this->assertEquals('', $this->request->getMethod());
     }
 
-    public function testMethodErrorShouldBeFalseByDefault() : void
+    public function testMethodErrorShouldBeFalseByDefault(): void
     {
         $this->assertFalse($this->request->isMethodError());
     }
 
-    public function testMethodAccessorsShouldWorkUnderNormalInput() : void
+    public function testMethodAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->request->setMethod('foo');
         $this->assertEquals('foo', $this->request->getMethod());
     }
 
-    public function testSettingMethodWithInvalidNameShouldSetError() : void
+    public function testSettingMethodWithInvalidNameShouldSetError(): void
     {
         foreach (['1ad', 'abc-123', 'ad$$832r#@'] as $method) {
             $this->request->setMethod($method);
@@ -153,23 +153,23 @@ class RequestTest extends TestCase
         }
     }
 
-    public function testIdShouldBeNullByDefault() : void
+    public function testIdShouldBeNullByDefault(): void
     {
         $this->assertNull($this->request->getId());
     }
 
-    public function testIdAccessorsShouldWorkUnderNormalInput() : void
+    public function testIdAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->request->setId('foo');
         $this->assertEquals('foo', $this->request->getId());
     }
 
-    public function testVersionShouldBeJSONRpcV1ByDefault() : void
+    public function testVersionShouldBeJSONRpcV1ByDefault(): void
     {
         $this->assertEquals('1.0', $this->request->getVersion());
     }
 
-    public function testVersionShouldBeLimitedToV1AndV2() : void
+    public function testVersionShouldBeLimitedToV1AndV2(): void
     {
         $this->testVersionShouldBeJSONRpcV1ByDefault();
         $this->request->setVersion('2.0');
@@ -178,7 +178,7 @@ class RequestTest extends TestCase
         $this->assertEquals('1.0', $this->request->getVersion());
     }
 
-    public function testShouldBeAbleToLoadRequestFromJSONString() : void
+    public function testShouldBeAbleToLoadRequestFromJSONString(): void
     {
         $options = $this->getOptions();
         $json    = Json::encode($options);
@@ -189,7 +189,7 @@ class RequestTest extends TestCase
         $this->assertEquals($options['params'], $this->request->getParams());
     }
 
-    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent() : void
+    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
     {
         $options = $this->getOptions();
         $options['jsonrpc'] = '2.0';
@@ -198,7 +198,7 @@ class RequestTest extends TestCase
         $this->assertEquals('2.0', $this->request->getVersion());
     }
 
-    public function testShouldBeAbleToCastToJSON() : void
+    public function testShouldBeAbleToCastToJSON(): void
     {
         $options = $this->getOptions();
         $this->request->setOptions($options);
@@ -206,7 +206,7 @@ class RequestTest extends TestCase
         $this->validateJSON($json, $options);
     }
 
-    public function testCastingToStringShouldCastToJSON() : void
+    public function testCastingToStringShouldCastToJSON(): void
     {
         $options = $this->getOptions();
         $this->request->setOptions($options);
@@ -217,20 +217,20 @@ class RequestTest extends TestCase
     /**
      * @group Laminas-6187
      */
-    public function testMethodNamesShouldAllowDotNamespacing() : void
+    public function testMethodNamesShouldAllowDotNamespacing(): void
     {
         $this->request->setMethod('foo.bar');
         $this->assertEquals('foo.bar', $this->request->getMethod());
     }
 
-    public function testIsParseErrorSetOnMalformedJson() : void
+    public function testIsParseErrorSetOnMalformedJson(): void
     {
         $testJson = '{"id":1, "method": "test", "params:"[1,2,3]}';
         $this->request->loadJson($testJson);
         $this->assertTrue($this->request->isParseError());
     }
 
-    public function getOptions() : array
+    public function getOptions(): array
     {
         return [
             'method' => 'foo',
@@ -243,7 +243,7 @@ class RequestTest extends TestCase
         ];
     }
 
-    public function validateJSON(string $json, array $options) : void
+    public function validateJSON(string $json, array $options): void
     {
         $test = Json::decode($json, Json::TYPE_ARRAY);
         $this->assertIsArray($test, var_export($json, true));

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -32,13 +32,13 @@ class RequestTest extends TestCase
         $this->request = new Request();
     }
 
-    public function testShouldHaveNoParamsByDefault()
+    public function testShouldHaveNoParamsByDefault() : void
     {
         $params = $this->request->getParams();
         $this->assertEmpty($params);
     }
 
-    public function testShouldBeAbleToAddAParamAsValueOnly()
+    public function testShouldBeAbleToAddAParamAsValueOnly() : void
     {
         $this->request->addParam('foo');
         $params = $this->request->getParams();
@@ -47,7 +47,7 @@ class RequestTest extends TestCase
         $this->assertEquals('foo', $test);
     }
 
-    public function testShouldBeAbleToAddAParamAsKeyValuePair()
+    public function testShouldBeAbleToAddAParamAsKeyValuePair() : void
     {
         $this->request->addParam('bar', 'foo');
         $params = $this->request->getParams();
@@ -56,7 +56,7 @@ class RequestTest extends TestCase
         $this->assertEquals('bar', $params['foo']);
     }
 
-    public function testInvalidKeysShouldBeIgnored()
+    public function testInvalidKeysShouldBeIgnored() : void
     {
         $count = 0;
         foreach ([['foo', true], ['foo', new \stdClass], ['foo', []]] as $spec) {
@@ -68,7 +68,7 @@ class RequestTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToAddMultipleIndexedParamsAtOnce()
+    public function testShouldBeAbleToAddMultipleIndexedParamsAtOnce() : void
     {
         $params = [
             'foo',
@@ -80,7 +80,7 @@ class RequestTest extends TestCase
         $this->assertSame($params, $test);
     }
 
-    public function testShouldBeAbleToAddMultipleNamedParamsAtOnce()
+    public function testShouldBeAbleToAddMultipleNamedParamsAtOnce() : void
     {
         $params = [
             'foo' => 'bar',
@@ -92,7 +92,7 @@ class RequestTest extends TestCase
         $this->assertSame($params, $test);
     }
 
-    public function testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce()
+    public function testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce() : void
     {
         $params = [
             'foo' => 'bar',
@@ -107,7 +107,7 @@ class RequestTest extends TestCase
         $this->assertContains('baz', $test);
     }
 
-    public function testSetParamsShouldOverwriteParams()
+    public function testSetParamsShouldOverwriteParams() : void
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = [
@@ -119,7 +119,7 @@ class RequestTest extends TestCase
         $this->assertSame($params, $this->request->getParams());
     }
 
-    public function testShouldBeAbleToRetrieveParamByKeyOrIndex()
+    public function testShouldBeAbleToRetrieveParamByKeyOrIndex() : void
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = $this->request->getParams();
@@ -128,23 +128,23 @@ class RequestTest extends TestCase
         $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, 1));
     }
 
-    public function testMethodShouldBeNullByDefault()
+    public function testMethodShouldBeNullByDefault() : void
     {
         $this->assertNull($this->request->getMethod());
     }
 
-    public function testMethodErrorShouldBeFalseByDefault()
+    public function testMethodErrorShouldBeFalseByDefault() : void
     {
         $this->assertFalse($this->request->isMethodError());
     }
 
-    public function testMethodAccessorsShouldWorkUnderNormalInput()
+    public function testMethodAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->request->setMethod('foo');
         $this->assertEquals('foo', $this->request->getMethod());
     }
 
-    public function testSettingMethodWithInvalidNameShouldSetError()
+    public function testSettingMethodWithInvalidNameShouldSetError() : void
     {
         foreach (['1ad', 'abc-123', 'ad$$832r#@'] as $method) {
             $this->request->setMethod($method);
@@ -153,23 +153,23 @@ class RequestTest extends TestCase
         }
     }
 
-    public function testIdShouldBeNullByDefault()
+    public function testIdShouldBeNullByDefault() : void
     {
         $this->assertNull($this->request->getId());
     }
 
-    public function testIdAccessorsShouldWorkUnderNormalInput()
+    public function testIdAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->request->setId('foo');
         $this->assertEquals('foo', $this->request->getId());
     }
 
-    public function testVersionShouldBeJSONRpcV1ByDefault()
+    public function testVersionShouldBeJSONRpcV1ByDefault() : void
     {
         $this->assertEquals('1.0', $this->request->getVersion());
     }
 
-    public function testVersionShouldBeLimitedToV1AndV2()
+    public function testVersionShouldBeLimitedToV1AndV2() : void
     {
         $this->testVersionShouldBeJSONRpcV1ByDefault();
         $this->request->setVersion('2.0');
@@ -178,7 +178,7 @@ class RequestTest extends TestCase
         $this->assertEquals('1.0', $this->request->getVersion());
     }
 
-    public function testShouldBeAbleToLoadRequestFromJSONString()
+    public function testShouldBeAbleToLoadRequestFromJSONString() : void
     {
         $options = $this->getOptions();
         $json    = Json::encode($options);
@@ -189,7 +189,7 @@ class RequestTest extends TestCase
         $this->assertEquals($options['params'], $this->request->getParams());
     }
 
-    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent()
+    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent() : void
     {
         $options = $this->getOptions();
         $options['jsonrpc'] = '2.0';
@@ -198,7 +198,7 @@ class RequestTest extends TestCase
         $this->assertEquals('2.0', $this->request->getVersion());
     }
 
-    public function testShouldBeAbleToCastToJSON()
+    public function testShouldBeAbleToCastToJSON() : void
     {
         $options = $this->getOptions();
         $this->request->setOptions($options);
@@ -206,7 +206,7 @@ class RequestTest extends TestCase
         $this->validateJSON($json, $options);
     }
 
-    public function testCastingToStringShouldCastToJSON()
+    public function testCastingToStringShouldCastToJSON() : void
     {
         $options = $this->getOptions();
         $this->request->setOptions($options);
@@ -217,20 +217,20 @@ class RequestTest extends TestCase
     /**
      * @group Laminas-6187
      */
-    public function testMethodNamesShouldAllowDotNamespacing()
+    public function testMethodNamesShouldAllowDotNamespacing() : void
     {
         $this->request->setMethod('foo.bar');
         $this->assertEquals('foo.bar', $this->request->getMethod());
     }
 
-    public function testIsParseErrorSetOnMalformedJson()
+    public function testIsParseErrorSetOnMalformedJson() : void
     {
         $testJson = '{"id":1, "method": "test", "params:"[1,2,3]}';
         $this->request->loadJson($testJson);
         $this->assertTrue($this->request->isParseError());
     }
 
-    public function getOptions()
+    public function getOptions() : array
     {
         return [
             'method' => 'foo',
@@ -243,7 +243,7 @@ class RequestTest extends TestCase
         ];
     }
 
-    public function validateJSON($json, array $options)
+    public function validateJSON($json, array $options) : void
     {
         $test = Json::decode($json, Json::TYPE_ARRAY);
         $this->assertIsArray($test, var_export($json, 1));

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -59,7 +59,7 @@ class RequestTest extends TestCase
     public function testInvalidKeysShouldBeIgnored() : void
     {
         $count = 0;
-        foreach ([['foo', true], ['foo', new \stdClass], ['foo', []]] as $spec) {
+        foreach ([['foo', true], ['foo', new stdClass()], ['foo', []]] as $spec) {
             $this->request->addParam($spec[0], $spec[1]);
             $this->assertNull($this->request->getParam('foo'));
             $params = $this->request->getParams();

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -243,7 +243,7 @@ class RequestTest extends TestCase
         ];
     }
 
-    public function validateJSON($json, array $options) : void
+    public function validateJSON(string $json, array $options) : void
     {
         $test = Json::decode($json, Json::TYPE_ARRAY);
         $this->assertIsArray($test, var_export($json, 1));

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -13,6 +13,11 @@ namespace LaminasTest\Json\Server;
 use Laminas\Json\Json;
 use Laminas\Json\Server\Request;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function array_shift;
+use function array_values;
+use function var_export;
 
 class RequestTest extends TestCase
 {

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -30,12 +30,12 @@ class ResponseTest extends TestCase
         $this->response = new Response();
     }
 
-    public function testResultShouldBeNullByDefault()
+    public function testResultShouldBeNullByDefault() : void
     {
         $this->assertNull($this->response->getResult());
     }
 
-    public function testResultAccessorsShouldWorkWithNormalInput()
+    public function testResultAccessorsShouldWorkWithNormalInput() : void
     {
         foreach ([true, 'foo', 2, 2.0, [], ['foo' => 'bar']] as $result) {
             $this->response->setResult($result);
@@ -43,49 +43,49 @@ class ResponseTest extends TestCase
         }
     }
 
-    public function testResultShouldNotBeErrorByDefault()
+    public function testResultShouldNotBeErrorByDefault() : void
     {
         $this->assertFalse($this->response->isError());
     }
 
-    public function testSettingErrorShouldMarkRequestAsError()
+    public function testSettingErrorShouldMarkRequestAsError() : void
     {
         $error = new Error();
         $this->response->setError($error);
         $this->assertTrue($this->response->isError());
     }
 
-    public function testShouldBeAbleToRetrieveErrorObject()
+    public function testShouldBeAbleToRetrieveErrorObject() : void
     {
         $error = new Error();
         $this->response->setError($error);
         $this->assertSame($error, $this->response->getError());
     }
 
-    public function testErrorAccesorsShouldWorkWithNullInput()
+    public function testErrorAccesorsShouldWorkWithNullInput() : void
     {
         $this->response->setError(null);
         $this->assertNull($this->response->getError());
         $this->assertFalse($this->response->isError());
     }
 
-    public function testIdShouldBeNullByDefault()
+    public function testIdShouldBeNullByDefault() : void
     {
         $this->assertNull($this->response->getId());
     }
 
-    public function testIdAccesorsShouldWorkWithNormalInput()
+    public function testIdAccesorsShouldWorkWithNormalInput() : void
     {
         $this->response->setId('foo');
         $this->assertEquals('foo', $this->response->getId());
     }
 
-    public function testVersionShouldBeNullByDefault()
+    public function testVersionShouldBeNullByDefault() : void
     {
         $this->assertNull($this->response->getVersion());
     }
 
-    public function testVersionShouldBeLimitedToV2()
+    public function testVersionShouldBeLimitedToV2() : void
     {
         $this->response->setVersion('2.0');
         $this->assertEquals('2.0', $this->response->getVersion());
@@ -95,7 +95,7 @@ class ResponseTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToLoadResponseFromJSONString()
+    public function testShouldBeAbleToLoadResponseFromJSONString() : void
     {
         $options = $this->getOptions();
         $json    = Json::encode($options);
@@ -105,7 +105,7 @@ class ResponseTest extends TestCase
         $this->assertEquals($options['result'], $this->response->getResult());
     }
 
-    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent()
+    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent() : void
     {
         $options = $this->getOptions();
         $options['jsonrpc'] = '2.0';
@@ -114,7 +114,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('2.0', $this->response->getVersion());
     }
 
-    public function testResponseShouldBeAbleToCastToJSON()
+    public function testResponseShouldBeAbleToCastToJSON() : void
     {
         $this->response->setResult(true)
                        ->setId('foo')
@@ -133,7 +133,7 @@ class ResponseTest extends TestCase
         $this->assertEquals($this->response->getVersion(), $test['jsonrpc']);
     }
 
-    public function testResponseShouldCastErrorToJSONIfIsError()
+    public function testResponseShouldCastErrorToJSONIfIsError() : void
     {
         $error = new Error();
         $error->setCode(Error::ERROR_INTERNAL)
@@ -155,7 +155,7 @@ class ResponseTest extends TestCase
         $this->assertEquals($error->getMessage(), $test['error']['message']);
     }
 
-    public function testCastToStringShouldCastToJSON()
+    public function testCastToStringShouldCastToJSON() : void
     {
         $this->response->setResult(true)
                        ->setId('foo');
@@ -179,7 +179,7 @@ class ResponseTest extends TestCase
      *
      * @dataProvider provideScalarJSONResponses
      */
-    public function testLoadingScalarJSONResponseShouldThrowException($json)
+    public function testLoadingScalarJSONResponseShouldThrowException($json) : void
     {
         $this->expectException(RuntimeException::class);
         $this->response->loadJson($json);
@@ -188,12 +188,12 @@ class ResponseTest extends TestCase
     /**
      * @return string[][]
      */
-    public function provideScalarJSONResponses()
+    public function provideScalarJSONResponses() : array
     {
         return [[''], ['true'], ['null'], ['3'], ['"invalid"']];
     }
 
-    public function getOptions()
+    public function getOptions() : array
     {
         return [
             'result' => [
@@ -208,7 +208,7 @@ class ResponseTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-json-server/pull/2
      */
-    public function testValueOfZeroForOptionsKeyShouldNotBeInterpretedAsVersionKey()
+    public function testValueOfZeroForOptionsKeyShouldNotBeInterpretedAsVersionKey() : void
     {
         $this->response->setOptions([
             0 => '2.0',
@@ -220,7 +220,7 @@ class ResponseTest extends TestCase
      * Assert that error data can be omitted
      * @see https://www.jsonrpc.org/specification#response_object
      */
-    public function testSetOptionsAcceptsErrorWithEmptyDate()
+    public function testSetOptionsAcceptsErrorWithEmptyDate() : void
     {
         $this->response->setOptions([
             'error' => [

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json\Json;

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -179,7 +179,7 @@ class ResponseTest extends TestCase
      *
      * @dataProvider provideScalarJSONResponses
      */
-    public function testLoadingScalarJSONResponseShouldThrowException($json) : void
+    public function testLoadingScalarJSONResponseShouldThrowException(string $json) : void
     {
         $this->expectException(RuntimeException::class);
         $this->response->loadJson($json);

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -89,7 +89,7 @@ class ResponseTest extends TestCase
     {
         $this->response->setVersion('2.0');
         $this->assertEquals('2.0', $this->response->getVersion());
-        foreach (['a', 1, '1.0', true] as $version) {
+        foreach (['a', '1.0'] as $version) {
             $this->response->setVersion($version);
             $this->assertNull($this->response->getVersion());
         }

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -25,17 +25,17 @@ class ResponseTest extends TestCase
      *
      * @return void
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->response = new Response();
     }
 
-    public function testResultShouldBeNullByDefault() : void
+    public function testResultShouldBeNullByDefault(): void
     {
         $this->assertNull($this->response->getResult());
     }
 
-    public function testResultAccessorsShouldWorkWithNormalInput() : void
+    public function testResultAccessorsShouldWorkWithNormalInput(): void
     {
         foreach ([true, 'foo', 2, 2.0, [], ['foo' => 'bar']] as $result) {
             $this->response->setResult($result);
@@ -43,49 +43,49 @@ class ResponseTest extends TestCase
         }
     }
 
-    public function testResultShouldNotBeErrorByDefault() : void
+    public function testResultShouldNotBeErrorByDefault(): void
     {
         $this->assertFalse($this->response->isError());
     }
 
-    public function testSettingErrorShouldMarkRequestAsError() : void
+    public function testSettingErrorShouldMarkRequestAsError(): void
     {
         $error = new Error();
         $this->response->setError($error);
         $this->assertTrue($this->response->isError());
     }
 
-    public function testShouldBeAbleToRetrieveErrorObject() : void
+    public function testShouldBeAbleToRetrieveErrorObject(): void
     {
         $error = new Error();
         $this->response->setError($error);
         $this->assertSame($error, $this->response->getError());
     }
 
-    public function testErrorAccesorsShouldWorkWithNullInput() : void
+    public function testErrorAccesorsShouldWorkWithNullInput(): void
     {
         $this->response->setError(null);
         $this->assertNull($this->response->getError());
         $this->assertFalse($this->response->isError());
     }
 
-    public function testIdShouldBeNullByDefault() : void
+    public function testIdShouldBeNullByDefault(): void
     {
         $this->assertNull($this->response->getId());
     }
 
-    public function testIdAccesorsShouldWorkWithNormalInput() : void
+    public function testIdAccesorsShouldWorkWithNormalInput(): void
     {
         $this->response->setId('foo');
         $this->assertEquals('foo', $this->response->getId());
     }
 
-    public function testVersionShouldBeNullByDefault() : void
+    public function testVersionShouldBeNullByDefault(): void
     {
         $this->assertNull($this->response->getVersion());
     }
 
-    public function testVersionShouldBeLimitedToV2() : void
+    public function testVersionShouldBeLimitedToV2(): void
     {
         $this->response->setVersion('2.0');
         $this->assertEquals('2.0', $this->response->getVersion());
@@ -95,7 +95,7 @@ class ResponseTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToLoadResponseFromJSONString() : void
+    public function testShouldBeAbleToLoadResponseFromJSONString(): void
     {
         $options = $this->getOptions();
         $json    = Json::encode($options);
@@ -105,7 +105,7 @@ class ResponseTest extends TestCase
         $this->assertEquals($options['result'], $this->response->getResult());
     }
 
-    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent() : void
+    public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
     {
         $options = $this->getOptions();
         $options['jsonrpc'] = '2.0';
@@ -114,7 +114,7 @@ class ResponseTest extends TestCase
         $this->assertEquals('2.0', $this->response->getVersion());
     }
 
-    public function testResponseShouldBeAbleToCastToJSON() : void
+    public function testResponseShouldBeAbleToCastToJSON(): void
     {
         $this->response->setResult(true)
                        ->setId('foo')
@@ -133,7 +133,7 @@ class ResponseTest extends TestCase
         $this->assertEquals($this->response->getVersion(), $test['jsonrpc']);
     }
 
-    public function testResponseShouldCastErrorToJSONIfIsError() : void
+    public function testResponseShouldCastErrorToJSONIfIsError(): void
     {
         $error = new Error();
         $error->setCode(Error::ERROR_INTERNAL)
@@ -155,7 +155,7 @@ class ResponseTest extends TestCase
         $this->assertEquals($error->getMessage(), $test['error']['message']);
     }
 
-    public function testCastToStringShouldCastToJSON() : void
+    public function testCastToStringShouldCastToJSON(): void
     {
         $this->response->setResult(true)
                        ->setId('foo');
@@ -179,7 +179,7 @@ class ResponseTest extends TestCase
      *
      * @dataProvider provideScalarJSONResponses
      */
-    public function testLoadingScalarJSONResponseShouldThrowException(string $json) : void
+    public function testLoadingScalarJSONResponseShouldThrowException(string $json): void
     {
         $this->expectException(RuntimeException::class);
         $this->response->loadJson($json);
@@ -188,12 +188,12 @@ class ResponseTest extends TestCase
     /**
      * @return string[][]
      */
-    public function provideScalarJSONResponses() : array
+    public function provideScalarJSONResponses(): array
     {
         return [[''], ['true'], ['null'], ['3'], ['"invalid"']];
     }
 
-    public function getOptions() : array
+    public function getOptions(): array
     {
         return [
             'result' => [
@@ -208,7 +208,7 @@ class ResponseTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-json-server/pull/2
      */
-    public function testValueOfZeroForOptionsKeyShouldNotBeInterpretedAsVersionKey() : void
+    public function testValueOfZeroForOptionsKeyShouldNotBeInterpretedAsVersionKey(): void
     {
         $this->response->setOptions([
             0 => '2.0',
@@ -220,7 +220,7 @@ class ResponseTest extends TestCase
      * Assert that error data can be omitted
      * @see https://www.jsonrpc.org/specification#response_object
      */
-    public function testSetOptionsAcceptsErrorWithEmptyDate() : void
+    public function testSetOptionsAcceptsErrorWithEmptyDate(): void
     {
         $this->response->setOptions([
             'error' => [

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -39,7 +39,7 @@ class ResponseTest extends TestCase
     {
         foreach ([true, 'foo', 2, 2.0, [], ['foo' => 'bar']] as $result) {
             $this->response->setResult($result);
-            $this->assertEquals($result, $this->response->getResult());
+            $this->assertSame($result, $this->response->getResult());
         }
     }
 
@@ -77,7 +77,7 @@ class ResponseTest extends TestCase
     public function testIdAccesorsShouldWorkWithNormalInput(): void
     {
         $this->response->setId('foo');
-        $this->assertEquals('foo', $this->response->getId());
+        $this->assertSame('foo', $this->response->getId());
     }
 
     public function testVersionShouldBeNullByDefault(): void
@@ -88,7 +88,7 @@ class ResponseTest extends TestCase
     public function testVersionShouldBeLimitedToV2(): void
     {
         $this->response->setVersion('2.0');
-        $this->assertEquals('2.0', $this->response->getVersion());
+        $this->assertSame('2.0', $this->response->getVersion());
         foreach (['a', '1.0'] as $version) {
             $this->response->setVersion($version);
             $this->assertNull($this->response->getVersion());
@@ -101,8 +101,8 @@ class ResponseTest extends TestCase
         $json    = Json::encode($options);
         $this->response->loadJSON($json);
 
-        $this->assertEquals('foobar', $this->response->getId());
-        $this->assertEquals($options['result'], $this->response->getResult());
+        $this->assertSame('foobar', $this->response->getId());
+        $this->assertSame($options['result'], $this->response->getResult());
     }
 
     public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
@@ -111,7 +111,7 @@ class ResponseTest extends TestCase
         $options['jsonrpc'] = '2.0';
         $json    = Json::encode($options);
         $this->response->loadJSON($json);
-        $this->assertEquals('2.0', $this->response->getVersion());
+        $this->assertSame('2.0', $this->response->getVersion());
     }
 
     public function testResponseShouldBeAbleToCastToJSON(): void
@@ -129,8 +129,8 @@ class ResponseTest extends TestCase
         $this->assertArrayHasKey('jsonrpc', $test);
 
         $this->assertTrue($test['result']);
-        $this->assertEquals($this->response->getId(), $test['id']);
-        $this->assertEquals($this->response->getVersion(), $test['jsonrpc']);
+        $this->assertSame($this->response->getId(), $test['id']);
+        $this->assertSame($this->response->getVersion(), $test['jsonrpc']);
     }
 
     public function testResponseShouldCastErrorToJSONIfIsError(): void
@@ -150,9 +150,9 @@ class ResponseTest extends TestCase
         $this->assertArrayHasKey('id', $test);
         $this->assertArrayNotHasKey('jsonrpc', $test);
 
-        $this->assertEquals($this->response->getId(), $test['id']);
-        $this->assertEquals($error->getCode(), $test['error']['code']);
-        $this->assertEquals($error->getMessage(), $test['error']['message']);
+        $this->assertSame($this->response->getId(), $test['id']);
+        $this->assertSame($error->getCode(), $test['error']['code']);
+        $this->assertSame($error->getMessage(), $test['error']['message']);
     }
 
     public function testCastToStringShouldCastToJSON(): void
@@ -169,7 +169,7 @@ class ResponseTest extends TestCase
         $this->assertArrayNotHasKey('jsonrpc', $test);
 
         $this->assertTrue($test['result']);
-        $this->assertEquals($this->response->getId(), $test['id']);
+        $this->assertSame($this->response->getId(), $test['id']);
     }
 
     /**
@@ -229,8 +229,8 @@ class ResponseTest extends TestCase
             ],
         ]);
         $this->assertInstanceOf(Error::class, $this->response->getError());
-        $this->assertEquals(-32000, $this->response->getError()->getCode());
-        $this->assertEquals('Lorem Ipsum', $this->response->getError()->getMessage());
-        $this->assertEquals(null, $this->response->getError()->getData());
+        $this->assertSame(-32000, $this->response->getError()->getCode());
+        $this->assertSame('Lorem Ipsum', $this->response->getError()->getMessage());
+        $this->assertSame(null, $this->response->getError()->getData());
     }
 }

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -77,7 +77,7 @@ class ServerTest extends TestCase
             }
             $this->assertTrue(
                 $test->hasMethod($method),
-                'Testing for method ' . $method . ' against ' . var_export($test, 1)
+                'Testing for method ' . $method . ' against ' . var_export($test, true)
             );
         }
     }
@@ -102,7 +102,7 @@ class ServerTest extends TestCase
             }
             $this->assertTrue(
                 $test->hasMethod($method),
-                'Testing for method ' . $method . ' against ' . var_export($test, 1)
+                'Testing for method ' . $method . ' against ' . var_export($test, true)
             );
         }
     }
@@ -260,12 +260,12 @@ class ServerTest extends TestCase
 
     public function testHandleValidMethodWithNULLParamValueShouldWork() : void
     {
-        $this->server->setClass(__NAMESPACE__ . '\\TestAsset\\Foo')
+        $this->server->setClass(TestAsset\Foo::class)
                      ->addFunction(__NAMESPACE__ . '\\TestAsset\\FooFunc')
                      ->setReturnResponse(true);
         $request = $this->server->getRequest();
         $request->setMethod('bar')
-                ->setParams([true, null, 'bar'])
+                ->setParams([true, 'due', 'bar'])
                 ->setId('foo');
         $response = $this->server->handle();
         $this->assertInstanceOf(Response::class, $response);
@@ -286,7 +286,7 @@ class ServerTest extends TestCase
         $result = $response->getResult();
         $this->assertIsArray($result);
         $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, 1));
+        $this->assertEquals('two', $result[1], var_export($result, true));
         $this->assertNull($result[2]);
     }
 
@@ -304,7 +304,7 @@ class ServerTest extends TestCase
         $result = $response->getResult();
         $this->assertIsArray($result);
         $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, 1));
+        $this->assertEquals('two', $result[1], var_export($result, true));
         $this->assertNull($result[2]);
     }
 

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json;

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -18,6 +18,12 @@ use Laminas\Json\Server\Response;
 use Laminas\Server\Reflection\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+use function get_class_methods;
+use function ob_get_clean;
+use function ob_start;
+use function var_export;
+
 class ServerTest extends TestCase
 {
     public function dummyCallable() : void

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -16,6 +16,8 @@ use Laminas\Json\Server\Error;
 use Laminas\Json\Server\Request;
 use Laminas\Json\Server\Response;
 use Laminas\Server\Reflection\Exception\RuntimeException;
+use LaminasTest\Json\Server\TestAsset\ServiceA;
+use LaminasTest\Json\Server\TestAsset\ServiceB;
 use PHPUnit\Framework\TestCase;
 
 use function count;
@@ -120,12 +122,12 @@ class ServerTest extends TestCase
 
     public function testNamingCollisionsShouldResolveToLastRegisteredMethod(): void
     {
-        $this->server->setClass(Request::class)
-                     ->setClass(Response::class);
+        $this->server->setClass(ServiceA::class)
+                     ->setClass(ServiceB::class);
         $methods = $this->server->getFunctions();
-        $this->assertTrue($methods->hasMethod('toJson'));
-        $toJSON = $methods->getMethod('toJson');
-        $this->assertEquals(Response::class, $toJSON->getCallback()->getClass());
+        $this->assertTrue($methods->hasMethod('hello'));
+        $toJSON = $methods->getMethod('hello');
+        $this->assertEquals(ServiceB::class, $toJSON->getCallback()->getClass());
     }
 
     public function testGetRequestShouldInstantiateRequestObjectByDefault(): void

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -26,7 +26,7 @@ use function var_export;
 
 class ServerTest extends TestCase
 {
-    public function dummyCallable() : void
+    public function dummyCallable(): void
     {
     }
 
@@ -36,19 +36,19 @@ class ServerTest extends TestCase
      *
      * @return void
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->server = new Server\Server();
     }
 
-    public function testShouldBeAbleToBindFunctionToServer() : void
+    public function testShouldBeAbleToBindFunctionToServer(): void
     {
         $this->server->addFunction('strtolower');
         $methods = $this->server->getFunctions();
         $this->assertTrue($methods->hasMethod('strtolower'));
     }
 
-    public function testShouldBeAbleToBindCallbackToServer() : void
+    public function testShouldBeAbleToBindCallbackToServer(): void
     {
         try {
             $this->server->addFunction([$this, 'dummyCallable']);
@@ -59,14 +59,14 @@ class ServerTest extends TestCase
         $this->assertTrue($methods->hasMethod('dummyCallable'));
     }
 
-    public function testShouldBeAbleToBindClassToServer() : void
+    public function testShouldBeAbleToBindClassToServer(): void
     {
         $this->server->setClass(Server\Server::class);
         $test = $this->server->getFunctions();
         $this->assertNotEmpty($test);
     }
 
-    public function testBindingClassToServerShouldRegisterAllPublicMethods() : void
+    public function testBindingClassToServerShouldRegisterAllPublicMethods(): void
     {
         $this->server->setClass(Server\Server::class);
         $test = $this->server->getFunctions();
@@ -82,7 +82,7 @@ class ServerTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToBindObjectToServer() : void
+    public function testShouldBeAbleToBindObjectToServer(): void
     {
         $object = new Server\Server();
         $this->server->setClass($object);
@@ -90,7 +90,7 @@ class ServerTest extends TestCase
         $this->assertNotEmpty($test);
     }
 
-    public function testBindingObjectToServerShouldRegisterAllPublicMethods() : void
+    public function testBindingObjectToServerShouldRegisterAllPublicMethods(): void
     {
         $object = new Server\Server();
         $this->server->setClass($object);
@@ -107,7 +107,7 @@ class ServerTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToBindMultipleClassesAndObjectsToServer() : void
+    public function testShouldBeAbleToBindMultipleClassesAndObjectsToServer(): void
     {
         $this->server->setClass(Server\Server::class)
                      ->setClass(new Json\Json());
@@ -118,7 +118,7 @@ class ServerTest extends TestCase
         $this->assertGreaterThan(count($zjMethods), count($methods));
     }
 
-    public function testNamingCollisionsShouldResolveToLastRegisteredMethod() : void
+    public function testNamingCollisionsShouldResolveToLastRegisteredMethod(): void
     {
         $this->server->setClass(Request::class)
                      ->setClass(Response::class);
@@ -128,13 +128,13 @@ class ServerTest extends TestCase
         $this->assertEquals(Response::class, $toJSON->getCallback()->getClass());
     }
 
-    public function testGetRequestShouldInstantiateRequestObjectByDefault() : void
+    public function testGetRequestShouldInstantiateRequestObjectByDefault(): void
     {
         $request = $this->server->getRequest();
         $this->assertInstanceOf(Request::class, $request);
     }
 
-    public function testShouldAllowSettingRequestObjectManually() : void
+    public function testShouldAllowSettingRequestObjectManually(): void
     {
         $orig = $this->server->getRequest();
         $new  = new Request();
@@ -144,13 +144,13 @@ class ServerTest extends TestCase
         $this->assertNotSame($orig, $test);
     }
 
-    public function testGetResponseShouldInstantiateResponseObjectByDefault() : void
+    public function testGetResponseShouldInstantiateResponseObjectByDefault(): void
     {
         $response = $this->server->getResponse();
         $this->assertInstanceOf(Response::class, $response);
     }
 
-    public function testShouldAllowSettingResponseObjectManually() : void
+    public function testShouldAllowSettingResponseObjectManually(): void
     {
         $orig = $this->server->getResponse();
         $new  = new Response();
@@ -160,7 +160,7 @@ class ServerTest extends TestCase
         $this->assertNotSame($orig, $test);
     }
 
-    public function testFaultShouldCreateErrorResponse() : void
+    public function testFaultShouldCreateErrorResponse(): void
     {
         $response = $this->server->getResponse();
         $this->assertFalse($response->isError());
@@ -171,25 +171,25 @@ class ServerTest extends TestCase
         $this->assertEquals('error condition', $error->getMessage());
     }
 
-    public function testResponseShouldBeEmittedAutomaticallyByDefault() : void
+    public function testResponseShouldBeEmittedAutomaticallyByDefault(): void
     {
         $this->assertFalse($this->server->getReturnResponse());
     }
 
-    public function testShouldBeAbleToDisableAutomaticResponseEmission() : void
+    public function testShouldBeAbleToDisableAutomaticResponseEmission(): void
     {
         $this->testResponseShouldBeEmittedAutomaticallyByDefault();
         $this->server->setReturnResponse(true);
         $this->assertTrue($this->server->getReturnResponse());
     }
 
-    public function testShouldBeAbleToRetrieveSmdObject() : void
+    public function testShouldBeAbleToRetrieveSmdObject(): void
     {
         $smd = $this->server->getServiceMap();
         $this->assertInstanceOf(Server\Smd::class, $smd);
     }
 
-    public function testShouldBeAbleToSetArbitrarySmdMetadata() : void
+    public function testShouldBeAbleToSetArbitrarySmdMetadata(): void
     {
         $this->server->setTransport('POST')
                      ->setEnvelope('JSON-RPC-1.0')
@@ -206,7 +206,7 @@ class ServerTest extends TestCase
         $this->assertEquals('This is a test service', $this->server->getDescription());
     }
 
-    public function testSmdObjectRetrievedFromServerShouldReflectServerState() : void
+    public function testSmdObjectRetrievedFromServerShouldReflectServerState(): void
     {
         $this->server->addFunction('strtolower')
                      ->setClass(Server\Server::class)
@@ -237,7 +237,7 @@ class ServerTest extends TestCase
         }
     }
 
-    public function testHandleValidMethodShouldWork() : void
+    public function testHandleValidMethodShouldWork(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->addFunction(__NAMESPACE__ . '\\TestAsset\\FooFunc')
@@ -258,7 +258,7 @@ class ServerTest extends TestCase
         $this->assertFalse($response->isError());
     }
 
-    public function testHandleValidMethodWithNULLParamValueShouldWork() : void
+    public function testHandleValidMethodWithNULLParamValueShouldWork(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->addFunction(__NAMESPACE__ . '\\TestAsset\\FooFunc')
@@ -272,7 +272,7 @@ class ServerTest extends TestCase
         $this->assertFalse($response->isError());
     }
 
-    public function testHandleValidMethodWithTooFewParamsShouldPassDefaultsOrNullsForMissingParams() : void
+    public function testHandleValidMethodWithTooFewParamsShouldPassDefaultsOrNullsForMissingParams(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -290,7 +290,7 @@ class ServerTest extends TestCase
         $this->assertNull($result[2]);
     }
 
-    public function testHandleValidMethodWithTooFewAssociativeParamsShouldPassDefaultsOrNullsForMissingParams() : void
+    public function testHandleValidMethodWithTooFewAssociativeParamsShouldPassDefaultsOrNullsForMissingParams(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -308,7 +308,7 @@ class ServerTest extends TestCase
         $this->assertNull($result[2]);
     }
 
-    public function testHandleValidMethodWithTooManyParamsShouldWork() : void
+    public function testHandleValidMethodWithTooManyParamsShouldWork(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -326,7 +326,7 @@ class ServerTest extends TestCase
         $this->assertEquals('bar', $result[2]);
     }
 
-    public function testHandleShouldAllowNamedParamsInAnyOrder1() : void
+    public function testHandleShouldAllowNamedParamsInAnyOrder1(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -347,7 +347,7 @@ class ServerTest extends TestCase
         $this->assertEquals(3, $result[2]);
     }
 
-    public function testHandleShouldAllowNamedParamsInAnyOrder2() : void
+    public function testHandleShouldAllowNamedParamsInAnyOrder2(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -368,7 +368,7 @@ class ServerTest extends TestCase
         $this->assertEquals(3, $result[2]);
     }
 
-    public function testHandleValidWithoutRequiredParamShouldReturnError() : void
+    public function testHandleValidWithoutRequiredParamShouldReturnError(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -386,7 +386,7 @@ class ServerTest extends TestCase
         $this->assertEquals(Server\Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
     }
 
-    public function testHandleRequestWithErrorsShouldReturnErrorResponse() : void
+    public function testHandleRequestWithErrorsShouldReturnErrorResponse(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -396,7 +396,7 @@ class ServerTest extends TestCase
         $this->assertEquals(Server\Error::ERROR_INVALID_REQUEST, $response->getError()->getCode());
     }
 
-    public function testHandleRequestWithInvalidMethodShouldReturnErrorResponse() : void
+    public function testHandleRequestWithInvalidMethodShouldReturnErrorResponse(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -409,7 +409,7 @@ class ServerTest extends TestCase
         $this->assertEquals(Server\Error::ERROR_INVALID_METHOD, $response->getError()->getCode());
     }
 
-    public function testHandleRequestWithExceptionShouldReturnErrorResponse() : void
+    public function testHandleRequestWithExceptionShouldReturnErrorResponse(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -423,7 +423,7 @@ class ServerTest extends TestCase
         $this->assertEquals('application error', $response->getError()->getMessage());
     }
 
-    public function testHandleShouldEmitResponseByDefault() : void
+    public function testHandleShouldEmitResponseByDefault(): void
     {
         $this->server->setClass(TestAsset\Foo::class);
         $request = $this->server->getRequest();
@@ -444,7 +444,7 @@ class ServerTest extends TestCase
         $this->assertEquals($response->getId(), $decoded['id']);
     }
 
-    public function testResponseShouldBeEmptyWhenRequestHasNoId() : void
+    public function testResponseShouldBeEmptyWhenRequestHasNoId(): void
     {
         $this->server->setClass(TestAsset\Foo::class);
         $request = $this->server->getRequest();
@@ -457,7 +457,7 @@ class ServerTest extends TestCase
         $this->assertEmpty($buffer);
     }
 
-    public function testLoadFunctionsShouldLoadResultOfGetFunctions() : void
+    public function testLoadFunctionsShouldLoadResultOfGetFunctions(): void
     {
         $this->server->setClass(TestAsset\Foo::class);
         $functions = $this->server->getFunctions();
@@ -469,7 +469,7 @@ class ServerTest extends TestCase
     /**
      * @group Laminas-4604
      */
-    public function testAddFunctionAndClassThatContainsConstructor() : void
+    public function testAddFunctionAndClassThatContainsConstructor(): void
     {
         $bar = new TestAsset\Bar('unique');
 
@@ -498,7 +498,7 @@ class ServerTest extends TestCase
     /**
      * @group 3773
      */
-    public function testHandleWithNamedParamsShouldSetMissingDefaults1() : void
+    public function testHandleWithNamedParamsShouldSetMissingDefaults1(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -521,7 +521,7 @@ class ServerTest extends TestCase
     /**
      * @group 3773
      */
-    public function testHandleWithNamedParamsShouldSetMissingDefaults2() : void
+    public function testHandleWithNamedParamsShouldSetMissingDefaults2(): void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -541,7 +541,7 @@ class ServerTest extends TestCase
         $this->assertEquals(3, $result[2]);
     }
 
-    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys() : void
+    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys(): void
     {
         $server = $this->server;
         $server->setClass(TestAsset\FooParameters::class);
@@ -555,7 +555,7 @@ class ServerTest extends TestCase
         $this->assertEquals($response->getError()->getCode(), Error::ERROR_INVALID_PARAMS);
     }
 
-    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys1() : void
+    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys1(): void
     {
         $server = $this->server;
         $server->setClass(TestAsset\FooParameters::class);

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -41,14 +41,14 @@ class ServerTest extends TestCase
         $this->server = new Server\Server();
     }
 
-    public function testShouldBeAbleToBindFunctionToServer()
+    public function testShouldBeAbleToBindFunctionToServer() : void
     {
         $this->server->addFunction('strtolower');
         $methods = $this->server->getFunctions();
         $this->assertTrue($methods->hasMethod('strtolower'));
     }
 
-    public function testShouldBeAbleToBindCallbackToServer()
+    public function testShouldBeAbleToBindCallbackToServer() : void
     {
         try {
             $this->server->addFunction([$this, 'dummyCallable']);
@@ -59,14 +59,14 @@ class ServerTest extends TestCase
         $this->assertTrue($methods->hasMethod('dummyCallable'));
     }
 
-    public function testShouldBeAbleToBindClassToServer()
+    public function testShouldBeAbleToBindClassToServer() : void
     {
         $this->server->setClass(Server\Server::class);
         $test = $this->server->getFunctions();
         $this->assertNotEmpty($test);
     }
 
-    public function testBindingClassToServerShouldRegisterAllPublicMethods()
+    public function testBindingClassToServerShouldRegisterAllPublicMethods() : void
     {
         $this->server->setClass(Server\Server::class);
         $test = $this->server->getFunctions();
@@ -82,7 +82,7 @@ class ServerTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToBindObjectToServer()
+    public function testShouldBeAbleToBindObjectToServer() : void
     {
         $object = new Server\Server();
         $this->server->setClass($object);
@@ -90,7 +90,7 @@ class ServerTest extends TestCase
         $this->assertNotEmpty($test);
     }
 
-    public function testBindingObjectToServerShouldRegisterAllPublicMethods()
+    public function testBindingObjectToServerShouldRegisterAllPublicMethods() : void
     {
         $object = new Server\Server();
         $this->server->setClass($object);
@@ -107,7 +107,7 @@ class ServerTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToBindMultipleClassesAndObjectsToServer()
+    public function testShouldBeAbleToBindMultipleClassesAndObjectsToServer() : void
     {
         $this->server->setClass(Server\Server::class)
                      ->setClass(new Json\Json());
@@ -118,7 +118,7 @@ class ServerTest extends TestCase
         $this->assertGreaterThan(count($zjMethods), count($methods));
     }
 
-    public function testNamingCollisionsShouldResolveToLastRegisteredMethod()
+    public function testNamingCollisionsShouldResolveToLastRegisteredMethod() : void
     {
         $this->server->setClass(Request::class)
                      ->setClass(Response::class);
@@ -128,13 +128,13 @@ class ServerTest extends TestCase
         $this->assertEquals(Response::class, $toJSON->getCallback()->getClass());
     }
 
-    public function testGetRequestShouldInstantiateRequestObjectByDefault()
+    public function testGetRequestShouldInstantiateRequestObjectByDefault() : void
     {
         $request = $this->server->getRequest();
         $this->assertInstanceOf(Request::class, $request);
     }
 
-    public function testShouldAllowSettingRequestObjectManually()
+    public function testShouldAllowSettingRequestObjectManually() : void
     {
         $orig = $this->server->getRequest();
         $new  = new Request();
@@ -144,13 +144,13 @@ class ServerTest extends TestCase
         $this->assertNotSame($orig, $test);
     }
 
-    public function testGetResponseShouldInstantiateResponseObjectByDefault()
+    public function testGetResponseShouldInstantiateResponseObjectByDefault() : void
     {
         $response = $this->server->getResponse();
         $this->assertInstanceOf(Response::class, $response);
     }
 
-    public function testShouldAllowSettingResponseObjectManually()
+    public function testShouldAllowSettingResponseObjectManually() : void
     {
         $orig = $this->server->getResponse();
         $new  = new Response();
@@ -160,7 +160,7 @@ class ServerTest extends TestCase
         $this->assertNotSame($orig, $test);
     }
 
-    public function testFaultShouldCreateErrorResponse()
+    public function testFaultShouldCreateErrorResponse() : void
     {
         $response = $this->server->getResponse();
         $this->assertFalse($response->isError());
@@ -171,25 +171,25 @@ class ServerTest extends TestCase
         $this->assertEquals('error condition', $error->getMessage());
     }
 
-    public function testResponseShouldBeEmittedAutomaticallyByDefault()
+    public function testResponseShouldBeEmittedAutomaticallyByDefault() : void
     {
         $this->assertFalse($this->server->getReturnResponse());
     }
 
-    public function testShouldBeAbleToDisableAutomaticResponseEmission()
+    public function testShouldBeAbleToDisableAutomaticResponseEmission() : void
     {
         $this->testResponseShouldBeEmittedAutomaticallyByDefault();
         $this->server->setReturnResponse(true);
         $this->assertTrue($this->server->getReturnResponse());
     }
 
-    public function testShouldBeAbleToRetrieveSmdObject()
+    public function testShouldBeAbleToRetrieveSmdObject() : void
     {
         $smd = $this->server->getServiceMap();
         $this->assertInstanceOf(Server\Smd::class, $smd);
     }
 
-    public function testShouldBeAbleToSetArbitrarySmdMetadata()
+    public function testShouldBeAbleToSetArbitrarySmdMetadata() : void
     {
         $this->server->setTransport('POST')
                      ->setEnvelope('JSON-RPC-1.0')
@@ -206,7 +206,7 @@ class ServerTest extends TestCase
         $this->assertEquals('This is a test service', $this->server->getDescription());
     }
 
-    public function testSmdObjectRetrievedFromServerShouldReflectServerState()
+    public function testSmdObjectRetrievedFromServerShouldReflectServerState() : void
     {
         $this->server->addFunction('strtolower')
                      ->setClass(Server\Server::class)
@@ -237,7 +237,7 @@ class ServerTest extends TestCase
         }
     }
 
-    public function testHandleValidMethodShouldWork()
+    public function testHandleValidMethodShouldWork() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->addFunction(__NAMESPACE__ . '\\TestAsset\\FooFunc')
@@ -258,7 +258,7 @@ class ServerTest extends TestCase
         $this->assertFalse($response->isError());
     }
 
-    public function testHandleValidMethodWithNULLParamValueShouldWork()
+    public function testHandleValidMethodWithNULLParamValueShouldWork() : void
     {
         $this->server->setClass(__NAMESPACE__ . '\\TestAsset\\Foo')
                      ->addFunction(__NAMESPACE__ . '\\TestAsset\\FooFunc')
@@ -272,7 +272,7 @@ class ServerTest extends TestCase
         $this->assertFalse($response->isError());
     }
 
-    public function testHandleValidMethodWithTooFewParamsShouldPassDefaultsOrNullsForMissingParams()
+    public function testHandleValidMethodWithTooFewParamsShouldPassDefaultsOrNullsForMissingParams() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -290,7 +290,7 @@ class ServerTest extends TestCase
         $this->assertNull($result[2]);
     }
 
-    public function testHandleValidMethodWithTooFewAssociativeParamsShouldPassDefaultsOrNullsForMissingParams()
+    public function testHandleValidMethodWithTooFewAssociativeParamsShouldPassDefaultsOrNullsForMissingParams() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -308,7 +308,7 @@ class ServerTest extends TestCase
         $this->assertNull($result[2]);
     }
 
-    public function testHandleValidMethodWithTooManyParamsShouldWork()
+    public function testHandleValidMethodWithTooManyParamsShouldWork() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -326,7 +326,7 @@ class ServerTest extends TestCase
         $this->assertEquals('bar', $result[2]);
     }
 
-    public function testHandleShouldAllowNamedParamsInAnyOrder1()
+    public function testHandleShouldAllowNamedParamsInAnyOrder1() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -347,7 +347,7 @@ class ServerTest extends TestCase
         $this->assertEquals(3, $result[2]);
     }
 
-    public function testHandleShouldAllowNamedParamsInAnyOrder2()
+    public function testHandleShouldAllowNamedParamsInAnyOrder2() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -368,7 +368,7 @@ class ServerTest extends TestCase
         $this->assertEquals(3, $result[2]);
     }
 
-    public function testHandleValidWithoutRequiredParamShouldReturnError()
+    public function testHandleValidWithoutRequiredParamShouldReturnError() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -386,7 +386,7 @@ class ServerTest extends TestCase
         $this->assertEquals(Server\Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
     }
 
-    public function testHandleRequestWithErrorsShouldReturnErrorResponse()
+    public function testHandleRequestWithErrorsShouldReturnErrorResponse() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -396,7 +396,7 @@ class ServerTest extends TestCase
         $this->assertEquals(Server\Error::ERROR_INVALID_REQUEST, $response->getError()->getCode());
     }
 
-    public function testHandleRequestWithInvalidMethodShouldReturnErrorResponse()
+    public function testHandleRequestWithInvalidMethodShouldReturnErrorResponse() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -409,7 +409,7 @@ class ServerTest extends TestCase
         $this->assertEquals(Server\Error::ERROR_INVALID_METHOD, $response->getError()->getCode());
     }
 
-    public function testHandleRequestWithExceptionShouldReturnErrorResponse()
+    public function testHandleRequestWithExceptionShouldReturnErrorResponse() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -423,7 +423,7 @@ class ServerTest extends TestCase
         $this->assertEquals('application error', $response->getError()->getMessage());
     }
 
-    public function testHandleShouldEmitResponseByDefault()
+    public function testHandleShouldEmitResponseByDefault() : void
     {
         $this->server->setClass(TestAsset\Foo::class);
         $request = $this->server->getRequest();
@@ -444,7 +444,7 @@ class ServerTest extends TestCase
         $this->assertEquals($response->getId(), $decoded['id']);
     }
 
-    public function testResponseShouldBeEmptyWhenRequestHasNoId()
+    public function testResponseShouldBeEmptyWhenRequestHasNoId() : void
     {
         $this->server->setClass(TestAsset\Foo::class);
         $request = $this->server->getRequest();
@@ -457,7 +457,7 @@ class ServerTest extends TestCase
         $this->assertEmpty($buffer);
     }
 
-    public function testLoadFunctionsShouldLoadResultOfGetFunctions()
+    public function testLoadFunctionsShouldLoadResultOfGetFunctions() : void
     {
         $this->server->setClass(TestAsset\Foo::class);
         $functions = $this->server->getFunctions();
@@ -469,7 +469,7 @@ class ServerTest extends TestCase
     /**
      * @group Laminas-4604
      */
-    public function testAddFunctionAndClassThatContainsConstructor()
+    public function testAddFunctionAndClassThatContainsConstructor() : void
     {
         $bar = new TestAsset\Bar('unique');
 
@@ -498,7 +498,7 @@ class ServerTest extends TestCase
     /**
      * @group 3773
      */
-    public function testHandleWithNamedParamsShouldSetMissingDefaults1()
+    public function testHandleWithNamedParamsShouldSetMissingDefaults1() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -521,7 +521,7 @@ class ServerTest extends TestCase
     /**
      * @group 3773
      */
-    public function testHandleWithNamedParamsShouldSetMissingDefaults2()
+    public function testHandleWithNamedParamsShouldSetMissingDefaults2() : void
     {
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
@@ -541,7 +541,7 @@ class ServerTest extends TestCase
         $this->assertEquals(3, $result[2]);
     }
 
-    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys()
+    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys() : void
     {
         $server = $this->server;
         $server->setClass(TestAsset\FooParameters::class);
@@ -555,7 +555,7 @@ class ServerTest extends TestCase
         $this->assertEquals($response->getError()->getCode(), Error::ERROR_INVALID_PARAMS);
     }
 
-    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys1()
+    public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys1() : void
     {
         $server = $this->server;
         $server->setClass(TestAsset\FooParameters::class);

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -127,7 +127,7 @@ class ServerTest extends TestCase
         $methods = $this->server->getFunctions();
         $this->assertTrue($methods->hasMethod('hello'));
         $toJSON = $methods->getMethod('hello');
-        $this->assertEquals(ServiceB::class, $toJSON->getCallback()->getClass());
+        $this->assertSame(ServiceB::class, $toJSON->getCallback()->getClass());
     }
 
     public function testGetRequestShouldInstantiateRequestObjectByDefault(): void
@@ -169,8 +169,8 @@ class ServerTest extends TestCase
         $this->server->fault('error condition', -32000);
         $this->assertTrue($response->isError());
         $error = $response->getError();
-        $this->assertEquals(-32000, $error->getCode());
-        $this->assertEquals('error condition', $error->getMessage());
+        $this->assertSame(-32000, $error->getCode());
+        $this->assertSame('error condition', $error->getMessage());
     }
 
     public function testResponseShouldBeEmittedAutomaticallyByDefault(): void
@@ -200,12 +200,12 @@ class ServerTest extends TestCase
                      ->setId('foobar')
                      ->setDescription('This is a test service');
 
-        $this->assertEquals('POST', $this->server->getTransport());
-        $this->assertEquals('JSON-RPC-1.0', $this->server->getEnvelope());
-        $this->assertEquals('application/x-json', $this->server->getContentType());
-        $this->assertEquals('/foo/bar', $this->server->getTarget());
-        $this->assertEquals('foobar', $this->server->getId());
-        $this->assertEquals('This is a test service', $this->server->getDescription());
+        $this->assertSame('POST', $this->server->getTransport());
+        $this->assertSame('JSON-RPC-1.0', $this->server->getEnvelope());
+        $this->assertSame('application/x-json', $this->server->getContentType());
+        $this->assertSame('/foo/bar', $this->server->getTarget());
+        $this->assertSame('foobar', $this->server->getId());
+        $this->assertSame('This is a test service', $this->server->getDescription());
     }
 
     public function testSmdObjectRetrievedFromServerShouldReflectServerState(): void
@@ -219,12 +219,12 @@ class ServerTest extends TestCase
                      ->setId('foobar')
                      ->setDescription('This is a test service');
         $smd = $this->server->getServiceMap();
-        $this->assertEquals('POST', $this->server->getTransport());
-        $this->assertEquals('JSON-RPC-1.0', $this->server->getEnvelope());
-        $this->assertEquals('application/x-json', $this->server->getContentType());
-        $this->assertEquals('/foo/bar', $this->server->getTarget());
-        $this->assertEquals('foobar', $this->server->getId());
-        $this->assertEquals('This is a test service', $this->server->getDescription());
+        $this->assertSame('POST', $this->server->getTransport());
+        $this->assertSame('JSON-RPC-1.0', $this->server->getEnvelope());
+        $this->assertSame('application/x-json', $this->server->getContentType());
+        $this->assertSame('/foo/bar', $this->server->getTarget());
+        $this->assertSame('foobar', $this->server->getId());
+        $this->assertSame('This is a test service', $this->server->getDescription());
 
         $services = $smd->getServices();
         $this->assertIsArray($services);
@@ -288,7 +288,7 @@ class ServerTest extends TestCase
         $result = $response->getResult();
         $this->assertIsArray($result);
         $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, true));
+        $this->assertSame('two', $result[1], var_export($result, true));
         $this->assertNull($result[2]);
     }
 
@@ -306,7 +306,7 @@ class ServerTest extends TestCase
         $result = $response->getResult();
         $this->assertIsArray($result);
         $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, true));
+        $this->assertSame('two', $result[1], var_export($result, true));
         $this->assertNull($result[2]);
     }
 
@@ -324,8 +324,8 @@ class ServerTest extends TestCase
         $result = $response->getResult();
         $this->assertIsArray($result);
         $this->assertCount(3, $result);
-        $this->assertEquals('foo', $result[1]);
-        $this->assertEquals('bar', $result[2]);
+        $this->assertSame('foo', $result[1]);
+        $this->assertSame('bar', $result[2]);
     }
 
     public function testHandleShouldAllowNamedParamsInAnyOrder1(): void
@@ -344,8 +344,8 @@ class ServerTest extends TestCase
         $result = $response->getResult();
 
         $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals(2, $result[1]);
+        $this->assertSame(true, $result[0]);
+        $this->assertSame('2', $result[1]);
         $this->assertEquals(3, $result[2]);
     }
 
@@ -365,9 +365,9 @@ class ServerTest extends TestCase
         $result = $response->getResult();
 
         $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals(2, $result[1]);
-        $this->assertEquals(3, $result[2]);
+        $this->assertSame(true, $result[0]);
+        $this->assertSame('2', $result[1]);
+        $this->assertSame(3, $result[2]);
     }
 
     public function testHandleValidWithoutRequiredParamShouldReturnError(): void
@@ -385,7 +385,7 @@ class ServerTest extends TestCase
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
+        $this->assertSame(Server\Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
     }
 
     public function testHandleRequestWithErrorsShouldReturnErrorResponse(): void
@@ -395,7 +395,7 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_INVALID_REQUEST, $response->getError()->getCode());
+        $this->assertSame(Server\Error::ERROR_INVALID_REQUEST, $response->getError()->getCode());
     }
 
     public function testHandleRequestWithInvalidMethodShouldReturnErrorResponse(): void
@@ -408,7 +408,7 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_INVALID_METHOD, $response->getError()->getCode());
+        $this->assertSame(Server\Error::ERROR_INVALID_METHOD, $response->getError()->getCode());
     }
 
     public function testHandleRequestWithExceptionShouldReturnErrorResponse(): void
@@ -421,8 +421,8 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_OTHER, $response->getError()->getCode());
-        $this->assertEquals('application error', $response->getError()->getMessage());
+        $this->assertSame(Server\Error::ERROR_OTHER, $response->getError()->getCode());
+        $this->assertSame('application error', $response->getError()->getMessage());
     }
 
     public function testHandleShouldEmitResponseByDefault(): void
@@ -442,8 +442,8 @@ class ServerTest extends TestCase
         $this->assertArrayHasKey('id', $decoded);
 
         $response = $this->server->getResponse();
-        $this->assertEquals($response->getResult(), $decoded['result']);
-        $this->assertEquals($response->getId(), $decoded['id']);
+        $this->assertSame($response->getResult(), $decoded['result']);
+        $this->assertSame($response->getId(), $decoded['id']);
     }
 
     public function testResponseShouldBeEmptyWhenRequestHasNoId(): void
@@ -465,7 +465,7 @@ class ServerTest extends TestCase
         $functions = $this->server->getFunctions();
         $server = new Server\Server();
         $server->loadFunctions($functions);
-        $this->assertEquals($functions->toArray(), $server->getFunctions()->toArray());
+        $this->assertSame($functions->toArray(), $server->getFunctions()->toArray());
     }
 
     /**
@@ -493,8 +493,8 @@ class ServerTest extends TestCase
         $this->assertContains('unique', $decoded['result']);
 
         $response = $this->server->getResponse();
-        $this->assertEquals($response->getResult(), $decoded['result']);
-        $this->assertEquals($response->getId(), $decoded['id']);
+        $this->assertSame($response->getResult(), $decoded['result']);
+        $this->assertSame($response->getId(), $decoded['id']);
     }
 
     /**
@@ -515,9 +515,9 @@ class ServerTest extends TestCase
         $result = $response->getResult();
 
         $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals(2, $result[1]);
-        $this->assertEquals(null, $result[2]);
+        $this->assertSame(true, $result[0]);
+        $this->assertSame('2', $result[1]);
+        $this->assertSame(null, $result[2]);
     }
 
     /**
@@ -538,9 +538,9 @@ class ServerTest extends TestCase
         $result = $response->getResult();
 
         $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals('two', $result[1]);
-        $this->assertEquals(3, $result[2]);
+        $this->assertSame(true, $result[0]);
+        $this->assertSame('two', $result[1]);
+        $this->assertSame(3, $result[2]);
     }
 
     public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys(): void
@@ -554,7 +554,7 @@ class ServerTest extends TestCase
         $server->handle();
 
         $response = $server->getResponse();
-        $this->assertEquals($response->getError()->getCode(), Error::ERROR_INVALID_PARAMS);
+        $this->assertSame($response->getError()->getCode(), Error::ERROR_INVALID_PARAMS);
     }
 
     public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys1(): void
@@ -568,6 +568,6 @@ class ServerTest extends TestCase
         $server->handle();
         $response = $server->getResponse();
         $this->assertNotEmpty($response->getError());
-        $this->assertEquals($response->getError()->getCode(), Error::ERROR_INVALID_PARAMS);
+        $this->assertSame($response->getError()->getCode(), Error::ERROR_INVALID_PARAMS);
     }
 }

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -74,7 +74,7 @@ class ServerTest extends TestCase
         $test = $this->server->getFunctions();
         $methods = get_class_methods(Server\Server::class);
         foreach ($methods as $method) {
-            if ('_' == $method[0]) {
+            if ('_' === $method[0]) {
                 continue;
             }
             $this->assertTrue(
@@ -99,7 +99,7 @@ class ServerTest extends TestCase
         $test = $this->server->getFunctions();
         $methods = get_class_methods($object);
         foreach ($methods as $method) {
-            if ('_' == $method[0]) {
+            if ('_' === $method[0]) {
                 continue;
             }
             $this->assertTrue(
@@ -232,7 +232,7 @@ class ServerTest extends TestCase
         $this->assertArrayHasKey('strtolower', $services);
         $methods = get_class_methods(Server\Server::class);
         foreach ($methods as $method) {
-            if ('_' == $method[0]) {
+            if ('_' === $method[0]) {
                 continue;
             }
             $this->assertArrayHasKey($method, $services);

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -57,7 +57,7 @@ class ServiceTest extends TestCase
     public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatStartingWithUnderscore(): void
     {
         $this->service->setName('_getMyProperty');
-        $this->assertEquals('_getMyProperty', $this->service->getName());
+        $this->assertSame('_getMyProperty', $this->service->getName());
     }
 
     public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpc(): void
@@ -71,7 +71,7 @@ class ServiceTest extends TestCase
     public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar(): void
     {
         $this->service->setName('rpcFoo');
-        $this->assertEquals('rpcFoo', $this->service->getName());
+        $this->assertSame('rpcFoo', $this->service->getName());
     }
     // @codingStandardsIgnoreEnd
 
@@ -79,29 +79,29 @@ class ServiceTest extends TestCase
     public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase(): void
     {
         $this->service->setName('RpcFoo');
-        $this->assertEquals('RpcFoo', $this->service->getName());
+        $this->assertSame('RpcFoo', $this->service->getName());
     }
     // @codingStandardsIgnoreEnd
 
     public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatContainingRpc(): void
     {
         $this->service->setName('_rpcFoo');
-        $this->assertEquals('_rpcFoo', $this->service->getName());
+        $this->assertSame('_rpcFoo', $this->service->getName());
 
         $this->service->setName('MyRpcFoo');
-        $this->assertEquals('MyRpcFoo', $this->service->getName());
+        $this->assertSame('MyRpcFoo', $this->service->getName());
     }
 
     public function testNameAccessorsShouldWorkWithNormalInput(): void
     {
-        $this->assertEquals('foo', $this->service->getName());
+        $this->assertSame('foo', $this->service->getName());
         $this->service->setName('bar');
-        $this->assertEquals('bar', $this->service->getName());
+        $this->assertSame('bar', $this->service->getName());
     }
 
     public function testTransportShouldDefaultToPost(): void
     {
-        $this->assertEquals('POST', $this->service->getTransport());
+        $this->assertSame('POST', $this->service->getTransport());
     }
 
     public function testSettingTransportThrowsExceptionWhenSetToGet(): void
@@ -121,33 +121,33 @@ class ServiceTest extends TestCase
     public function testTransportAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->service->setTransport('POST');
-        $this->assertEquals('POST', $this->service->getTransport());
+        $this->assertSame('POST', $this->service->getTransport());
     }
 
     public function testTargetShouldBeAnEmptyStringInitially(): void
     {
-        $this->assertEquals('', $this->service->getTarget());
+        $this->assertSame('', $this->service->getTarget());
     }
 
     public function testTargetAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testTargetShouldBeAnEmptyStringInitially();
         $this->service->setTarget('foo');
-        $this->assertEquals('foo', $this->service->getTarget());
+        $this->assertSame('foo', $this->service->getTarget());
     }
 
     public function testEnvelopeShouldBeJSONRpc1CompliantByDefault(): void
     {
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
+        $this->assertSame(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
     }
 
     public function testEnvelopeShouldOnlyComplyWithJSONRpc1And2(): void
     {
         $this->testEnvelopeShouldBeJSONRpc1CompliantByDefault();
         $this->service->setEnvelope(Smd::ENV_JSONRPC_2);
-        $this->assertEquals(Smd::ENV_JSONRPC_2, $this->service->getEnvelope());
+        $this->assertSame(Smd::ENV_JSONRPC_2, $this->service->getEnvelope());
         $this->service->setEnvelope(Smd::ENV_JSONRPC_1);
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
+        $this->assertSame(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
         try {
             $this->service->setEnvelope('JSON-P');
             $this->fail('Should not be able to set non-JSON-RPC spec envelopes');
@@ -168,7 +168,7 @@ class ServiceTest extends TestCase
         $params = $this->service->getParams();
         $this->assertCount(1, $params);
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type']);
+        $this->assertSame('integer', $param['type']);
     }
 
     public function testParamsShouldAcceptArrayOfTypes(): void
@@ -179,7 +179,7 @@ class ServiceTest extends TestCase
         $param  = array_shift($params);
         $test   = $param['type'];
         $this->assertIsArray($test);
-        $this->assertEquals($type, $test);
+        $this->assertSame($type, $test);
     }
 
     public function testInvalidParamTypeShouldThrowException(): void
@@ -199,11 +199,11 @@ class ServiceTest extends TestCase
         $this->assertCount(3, $params);
 
         $param = array_shift($params);
-        $this->assertEquals('string', $param['type'], var_export($params, true));
+        $this->assertSame('string', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type'], var_export($params, true));
+        $this->assertSame('boolean', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type'], var_export($params, true));
+        $this->assertSame('integer', $param['type'], var_export($params, true));
     }
 
     public function testShouldBeAbleToAddArbitraryParamOptions(): void
@@ -219,10 +219,10 @@ class ServiceTest extends TestCase
         );
         $params = $this->service->getParams();
         $param  = array_shift($params);
-        $this->assertEquals('foo', $param['name']);
+        $this->assertSame('foo', $param['name']);
         $this->assertFalse($param['optional']);
-        $this->assertEquals(1, $param['default']);
-        $this->assertEquals('Foo parameter', $param['description']);
+        $this->assertSame(1, $param['default']);
+        $this->assertSame('Foo parameter', $param['description']);
     }
 
     public function testShouldBeAbleToAddMultipleParamsAtOnce(): void
@@ -236,14 +236,14 @@ class ServiceTest extends TestCase
 
         $this->assertCount(3, $params);
         $param = array_shift($params);
-        $this->assertEquals('string', $param['type']);
-        $this->assertEquals('foo', $param['name']);
+        $this->assertSame('string', $param['type']);
+        $this->assertSame('foo', $param['name']);
 
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type']);
+        $this->assertSame('boolean', $param['type']);
 
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type']);
+        $this->assertSame('integer', $param['type']);
     }
 
     public function testSetparamsShouldOverwriteExistingParams(): void
@@ -270,7 +270,7 @@ class ServiceTest extends TestCase
     {
         $this->testReturnShouldBeNullByDefault();
         $this->service->setReturn('integer');
-        $this->assertEquals('integer', $this->service->getReturn());
+        $this->assertSame('integer', $this->service->getReturn());
     }
 
     public function testReturnAccessorsShouldAllowArrayOfTypes(): void
@@ -278,7 +278,7 @@ class ServiceTest extends TestCase
         $this->testReturnShouldBeNullByDefault();
         $type = ['integer', 'string'];
         $this->service->setReturn($type);
-        $this->assertEquals($type, $this->service->getReturn());
+        $this->assertSame($type, $this->service->getReturn());
     }
 
     public function testInvalidReturnTypeShouldThrowException(): void
@@ -322,22 +322,22 @@ class ServiceTest extends TestCase
     public function validateSmdArray(array $smd): void
     {
         $this->assertArrayHasKey('transport', $smd);
-        $this->assertEquals('POST', $smd['transport']);
+        $this->assertSame('POST', $smd['transport']);
 
         $this->assertArrayHasKey('envelope', $smd);
-        $this->assertEquals(Smd::ENV_JSONRPC_2, $smd['envelope']);
+        $this->assertSame(Smd::ENV_JSONRPC_2, $smd['envelope']);
 
         $this->assertArrayHasKey('parameters', $smd);
         $params = $smd['parameters'];
         $this->assertCount(3, $params);
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type']);
+        $this->assertSame('boolean', $param['type']);
         $param = array_shift($params);
-        $this->assertEquals('array', $param['type']);
+        $this->assertSame('array', $param['type']);
         $param = array_shift($params);
-        $this->assertEquals('object', $param['type']);
+        $this->assertSame('object', $param['type']);
 
         $this->assertArrayHasKey('returns', $smd);
-        $this->assertEquals('boolean', $smd['returns']);
+        $this->assertSame('boolean', $smd['returns']);
     }
 }

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -120,25 +120,16 @@ class ServiceTest extends TestCase
         $this->assertEquals('POST', $this->service->getTransport());
     }
 
-    public function testTargetShouldBeNullInitially() : void
+    public function testTargetShouldBeAnEmptyStringInitially() : void
     {
-        $this->assertNull($this->service->getTarget());
+        $this->assertEquals('', $this->service->getTarget());
     }
 
     public function testTargetAccessorsShouldWorkUnderNormalInput() : void
     {
-        $this->testTargetShouldBeNullInitially();
+        $this->testTargetShouldBeAnEmptyStringInitially();
         $this->service->setTarget('foo');
         $this->assertEquals('foo', $this->service->getTarget());
-    }
-
-    public function testTargetAccessorsShouldNormalizeToString() : void
-    {
-        $this->testTargetShouldBeNullInitially();
-        $this->service->setTarget(123);
-        $value = $this->service->getTarget();
-        $this->assertIsString($value);
-        $this->assertEquals((string) 123, $value);
     }
 
     public function testEnvelopeShouldBeJSONRpc1CompliantByDefault() : void
@@ -204,11 +195,11 @@ class ServiceTest extends TestCase
         $this->assertCount(3, $params);
 
         $param = array_shift($params);
-        $this->assertEquals('string', $param['type'], var_export($params, 1));
+        $this->assertEquals('string', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type'], var_export($params, 1));
+        $this->assertEquals('boolean', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type'], var_export($params, 1));
+        $this->assertEquals('integer', $param['type'], var_export($params, true));
     }
 
     public function testShouldBeAbleToAddArbitraryParamOptions() : void

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -124,14 +124,14 @@ class ServiceTest extends TestCase
         $this->assertSame('POST', $this->service->getTransport());
     }
 
-    public function testTargetShouldBeAnEmptyStringInitially(): void
+    public function testTargetShouldBeNullInitially(): void
     {
-        $this->assertSame('', $this->service->getTarget());
+        $this->assertNull($this->service->getTarget());
     }
 
     public function testTargetAccessorsShouldWorkUnderNormalInput(): void
     {
-        $this->testTargetShouldBeAnEmptyStringInitially();
+        $this->testTargetShouldBeNullInitially();
         $this->service->setTarget('foo');
         $this->assertSame('foo', $this->service->getTarget());
     }

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -28,39 +28,39 @@ class ServiceTest extends TestCase
      *
      * @return void
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->service = new Service('foo');
     }
 
-    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenNullProvided() : void
+    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenNullProvided(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('requires a name');
         new Service(null);
     }
 
-    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenArrayProvided() : void
+    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenArrayProvided(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('requires a name');
         new Service(null);
     }
 
-    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithInt() : void
+    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithInt(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid name');
         $this->service->setName('0ab-?');
     }
 
-    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatStartingWithUnderscore() : void
+    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatStartingWithUnderscore(): void
     {
         $this->service->setName('_getMyProperty');
         $this->assertEquals('_getMyProperty', $this->service->getName());
     }
 
-    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpc() : void
+    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpc(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid name');
@@ -68,7 +68,7 @@ class ServiceTest extends TestCase
     }
 
     // @codingStandardsIgnoreStart
-    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar() : void
+    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar(): void
     {
         $this->service->setName('rpcFoo');
         $this->assertEquals('rpcFoo', $this->service->getName());
@@ -76,14 +76,14 @@ class ServiceTest extends TestCase
     // @codingStandardsIgnoreEnd
 
     // @codingStandardsIgnoreStart
-    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase() : void
+    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase(): void
     {
         $this->service->setName('RpcFoo');
         $this->assertEquals('RpcFoo', $this->service->getName());
     }
     // @codingStandardsIgnoreEnd
 
-    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatContainingRpc() : void
+    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatContainingRpc(): void
     {
         $this->service->setName('_rpcFoo');
         $this->assertEquals('_rpcFoo', $this->service->getName());
@@ -92,56 +92,56 @@ class ServiceTest extends TestCase
         $this->assertEquals('MyRpcFoo', $this->service->getName());
     }
 
-    public function testNameAccessorsShouldWorkWithNormalInput() : void
+    public function testNameAccessorsShouldWorkWithNormalInput(): void
     {
         $this->assertEquals('foo', $this->service->getName());
         $this->service->setName('bar');
         $this->assertEquals('bar', $this->service->getName());
     }
 
-    public function testTransportShouldDefaultToPost() : void
+    public function testTransportShouldDefaultToPost(): void
     {
         $this->assertEquals('POST', $this->service->getTransport());
     }
 
-    public function testSettingTransportThrowsExceptionWhenSetToGet() : void
+    public function testSettingTransportThrowsExceptionWhenSetToGet(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid transport');
         $this->service->setTransport('GET');
     }
 
-    public function testSettingTransportThrowsExceptionWhenSetToRest() : void
+    public function testSettingTransportThrowsExceptionWhenSetToRest(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid transport');
         $this->service->setTransport('REST');
     }
 
-    public function testTransportAccessorsShouldWorkUnderNormalInput() : void
+    public function testTransportAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->service->setTransport('POST');
         $this->assertEquals('POST', $this->service->getTransport());
     }
 
-    public function testTargetShouldBeAnEmptyStringInitially() : void
+    public function testTargetShouldBeAnEmptyStringInitially(): void
     {
         $this->assertEquals('', $this->service->getTarget());
     }
 
-    public function testTargetAccessorsShouldWorkUnderNormalInput() : void
+    public function testTargetAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testTargetShouldBeAnEmptyStringInitially();
         $this->service->setTarget('foo');
         $this->assertEquals('foo', $this->service->getTarget());
     }
 
-    public function testEnvelopeShouldBeJSONRpc1CompliantByDefault() : void
+    public function testEnvelopeShouldBeJSONRpc1CompliantByDefault(): void
     {
         $this->assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
     }
 
-    public function testEnvelopeShouldOnlyComplyWithJSONRpc1And2() : void
+    public function testEnvelopeShouldOnlyComplyWithJSONRpc1And2(): void
     {
         $this->testEnvelopeShouldBeJSONRpc1CompliantByDefault();
         $this->service->setEnvelope(Smd::ENV_JSONRPC_2);
@@ -156,13 +156,13 @@ class ServiceTest extends TestCase
         }
     }
 
-    public function testShouldHaveNoParamsByDefault() : void
+    public function testShouldHaveNoParamsByDefault(): void
     {
         $params = $this->service->getParams();
         $this->assertEmpty($params);
     }
 
-    public function testShouldBeAbleToAddParamsByTypeOnly() : void
+    public function testShouldBeAbleToAddParamsByTypeOnly(): void
     {
         $this->service->addParam('integer');
         $params = $this->service->getParams();
@@ -171,7 +171,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('integer', $param['type']);
     }
 
-    public function testParamsShouldAcceptArrayOfTypes() : void
+    public function testParamsShouldAcceptArrayOfTypes(): void
     {
         $type   = ['integer', 'string'];
         $this->service->addParam($type);
@@ -182,14 +182,14 @@ class ServiceTest extends TestCase
         $this->assertEquals($type, $test);
     }
 
-    public function testInvalidParamTypeShouldThrowException() : void
+    public function testInvalidParamTypeShouldThrowException(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid param type');
         $this->service->addParam(new stdClass);
     }
 
-    public function testShouldBeAbleToOrderParams() : void
+    public function testShouldBeAbleToOrderParams(): void
     {
         $this->service->addParam('integer', [], 4)
                       ->addParam('string')
@@ -206,7 +206,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('integer', $param['type'], var_export($params, true));
     }
 
-    public function testShouldBeAbleToAddArbitraryParamOptions() : void
+    public function testShouldBeAbleToAddArbitraryParamOptions(): void
     {
         $this->service->addParam(
             'integer',
@@ -225,7 +225,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('Foo parameter', $param['description']);
     }
 
-    public function testShouldBeAbleToAddMultipleParamsAtOnce() : void
+    public function testShouldBeAbleToAddMultipleParamsAtOnce(): void
     {
         $this->service->addParams([
             ['type' => 'integer', 'order' => 4],
@@ -246,7 +246,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('integer', $param['type']);
     }
 
-    public function testSetparamsShouldOverwriteExistingParams() : void
+    public function testSetparamsShouldOverwriteExistingParams(): void
     {
         $this->testShouldBeAbleToAddMultipleParamsAtOnce();
         $params = $this->service->getParams();
@@ -261,19 +261,19 @@ class ServiceTest extends TestCase
         $this->assertCount(2, $test);
     }
 
-    public function testReturnShouldBeNullByDefault() : void
+    public function testReturnShouldBeNullByDefault(): void
     {
         $this->assertNull($this->service->getReturn());
     }
 
-    public function testReturnAccessorsShouldWorkWithNormalInput() : void
+    public function testReturnAccessorsShouldWorkWithNormalInput(): void
     {
         $this->testReturnShouldBeNullByDefault();
         $this->service->setReturn('integer');
         $this->assertEquals('integer', $this->service->getReturn());
     }
 
-    public function testReturnAccessorsShouldAllowArrayOfTypes() : void
+    public function testReturnAccessorsShouldAllowArrayOfTypes(): void
     {
         $this->testReturnShouldBeNullByDefault();
         $type = ['integer', 'string'];
@@ -281,21 +281,21 @@ class ServiceTest extends TestCase
         $this->assertEquals($type, $this->service->getReturn());
     }
 
-    public function testInvalidReturnTypeShouldThrowException() : void
+    public function testInvalidReturnTypeShouldThrowException(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid param type');
         $this->service->setReturn(new stdClass);
     }
 
-    public function testToArrayShouldCreateSmdCompatibleHash() : void
+    public function testToArrayShouldCreateSmdCompatibleHash(): void
     {
         $this->setupSmdValidationObject();
         $smd = $this->service->toArray();
         $this->validateSmdArray($smd);
     }
 
-    public function testTojsonShouldEmitJSON() : void
+    public function testTojsonShouldEmitJSON(): void
     {
         $this->setupSmdValidationObject();
         $json = $this->service->toJSON();
@@ -307,7 +307,7 @@ class ServiceTest extends TestCase
         $this->validateSmdArray($smd['foo']);
     }
 
-    public function setupSmdValidationObject() : void
+    public function setupSmdValidationObject(): void
     {
         $this->service->setName('foo')
                       ->setTransport('POST')
@@ -319,7 +319,7 @@ class ServiceTest extends TestCase
                       ->setReturn('boolean');
     }
 
-    public function validateSmdArray(array $smd) : void
+    public function validateSmdArray(array $smd): void
     {
         $this->assertArrayHasKey('transport', $smd);
         $this->assertEquals('POST', $smd['transport']);

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\Smd;
 
 use Laminas\Json\Server\Exception;

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -67,17 +67,21 @@ class ServiceTest extends TestCase
         $this->service->setName('rpc.Foo');
     }
 
+    // @codingStandardsIgnoreStart
     public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar() : void
     {
         $this->service->setName('rpcFoo');
         $this->assertEquals('rpcFoo', $this->service->getName());
     }
+    // @codingStandardsIgnoreEnd
 
+    // @codingStandardsIgnoreStart
     public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase() : void
     {
         $this->service->setName('RpcFoo');
         $this->assertEquals('RpcFoo', $this->service->getName());
     }
+    // @codingStandardsIgnoreEnd
 
     public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatContainingRpc() : void
     {

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -10,11 +10,15 @@ declare(strict_types=1);
 
 namespace LaminasTest\Json\Server\Smd;
 
+use Laminas\Json\Json;
 use Laminas\Json\Server\Exception;
 use Laminas\Json\Server\Smd;
 use Laminas\Json\Server\Smd\Service;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+
+use function array_shift;
+use function var_export;
 
 class ServiceTest extends TestCase
 {
@@ -300,7 +304,7 @@ class ServiceTest extends TestCase
     {
         $this->setupSmdValidationObject();
         $json = $this->service->toJSON();
-        $smd  = \Laminas\Json\Json::decode($json, \Laminas\Json\Json::TYPE_ARRAY);
+        $smd  = Json::decode($json, Json::TYPE_ARRAY);
 
         $this->assertArrayHasKey('foo', $smd);
         $this->assertIsArray($smd['foo']);

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -33,53 +33,53 @@ class ServiceTest extends TestCase
         $this->service = new Service('foo');
     }
 
-    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenNullProvided()
+    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenNullProvided() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('requires a name');
         new Service(null);
     }
 
-    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenArrayProvided()
+    public function testConstructorShouldThrowExceptionWhenNoNameSetWhenArrayProvided() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('requires a name');
         new Service(null);
     }
 
-    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithInt()
+    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithInt() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid name');
         $this->service->setName('0ab-?');
     }
 
-    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatStartingWithUnderscore()
+    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatStartingWithUnderscore() : void
     {
         $this->service->setName('_getMyProperty');
         $this->assertEquals('_getMyProperty', $this->service->getName());
     }
 
-    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpc()
+    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpc() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid name');
         $this->service->setName('rpc.Foo');
     }
 
-    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar()
+    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar() : void
     {
         $this->service->setName('rpcFoo');
         $this->assertEquals('rpcFoo', $this->service->getName());
     }
 
-    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase()
+    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase() : void
     {
         $this->service->setName('RpcFoo');
         $this->assertEquals('RpcFoo', $this->service->getName());
     }
 
-    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatContainingRpc()
+    public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatContainingRpc() : void
     {
         $this->service->setName('_rpcFoo');
         $this->assertEquals('_rpcFoo', $this->service->getName());
@@ -88,51 +88,51 @@ class ServiceTest extends TestCase
         $this->assertEquals('MyRpcFoo', $this->service->getName());
     }
 
-    public function testNameAccessorsShouldWorkWithNormalInput()
+    public function testNameAccessorsShouldWorkWithNormalInput() : void
     {
         $this->assertEquals('foo', $this->service->getName());
         $this->service->setName('bar');
         $this->assertEquals('bar', $this->service->getName());
     }
 
-    public function testTransportShouldDefaultToPost()
+    public function testTransportShouldDefaultToPost() : void
     {
         $this->assertEquals('POST', $this->service->getTransport());
     }
 
-    public function testSettingTransportThrowsExceptionWhenSetToGet()
+    public function testSettingTransportThrowsExceptionWhenSetToGet() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid transport');
         $this->service->setTransport('GET');
     }
 
-    public function testSettingTransportThrowsExceptionWhenSetToRest()
+    public function testSettingTransportThrowsExceptionWhenSetToRest() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid transport');
         $this->service->setTransport('REST');
     }
 
-    public function testTransportAccessorsShouldWorkUnderNormalInput()
+    public function testTransportAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->service->setTransport('POST');
         $this->assertEquals('POST', $this->service->getTransport());
     }
 
-    public function testTargetShouldBeNullInitially()
+    public function testTargetShouldBeNullInitially() : void
     {
         $this->assertNull($this->service->getTarget());
     }
 
-    public function testTargetAccessorsShouldWorkUnderNormalInput()
+    public function testTargetAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->testTargetShouldBeNullInitially();
         $this->service->setTarget('foo');
         $this->assertEquals('foo', $this->service->getTarget());
     }
 
-    public function testTargetAccessorsShouldNormalizeToString()
+    public function testTargetAccessorsShouldNormalizeToString() : void
     {
         $this->testTargetShouldBeNullInitially();
         $this->service->setTarget(123);
@@ -141,12 +141,12 @@ class ServiceTest extends TestCase
         $this->assertEquals((string) 123, $value);
     }
 
-    public function testEnvelopeShouldBeJSONRpc1CompliantByDefault()
+    public function testEnvelopeShouldBeJSONRpc1CompliantByDefault() : void
     {
         $this->assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
     }
 
-    public function testEnvelopeShouldOnlyComplyWithJSONRpc1And2()
+    public function testEnvelopeShouldOnlyComplyWithJSONRpc1And2() : void
     {
         $this->testEnvelopeShouldBeJSONRpc1CompliantByDefault();
         $this->service->setEnvelope(Smd::ENV_JSONRPC_2);
@@ -161,13 +161,13 @@ class ServiceTest extends TestCase
         }
     }
 
-    public function testShouldHaveNoParamsByDefault()
+    public function testShouldHaveNoParamsByDefault() : void
     {
         $params = $this->service->getParams();
         $this->assertEmpty($params);
     }
 
-    public function testShouldBeAbleToAddParamsByTypeOnly()
+    public function testShouldBeAbleToAddParamsByTypeOnly() : void
     {
         $this->service->addParam('integer');
         $params = $this->service->getParams();
@@ -176,7 +176,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('integer', $param['type']);
     }
 
-    public function testParamsShouldAcceptArrayOfTypes()
+    public function testParamsShouldAcceptArrayOfTypes() : void
     {
         $type   = ['integer', 'string'];
         $this->service->addParam($type);
@@ -187,14 +187,14 @@ class ServiceTest extends TestCase
         $this->assertEquals($type, $test);
     }
 
-    public function testInvalidParamTypeShouldThrowException()
+    public function testInvalidParamTypeShouldThrowException() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid param type');
         $this->service->addParam(new stdClass);
     }
 
-    public function testShouldBeAbleToOrderParams()
+    public function testShouldBeAbleToOrderParams() : void
     {
         $this->service->addParam('integer', [], 4)
                       ->addParam('string')
@@ -211,7 +211,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('integer', $param['type'], var_export($params, 1));
     }
 
-    public function testShouldBeAbleToAddArbitraryParamOptions()
+    public function testShouldBeAbleToAddArbitraryParamOptions() : void
     {
         $this->service->addParam(
             'integer',
@@ -230,7 +230,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('Foo parameter', $param['description']);
     }
 
-    public function testShouldBeAbleToAddMultipleParamsAtOnce()
+    public function testShouldBeAbleToAddMultipleParamsAtOnce() : void
     {
         $this->service->addParams([
             ['type' => 'integer', 'order' => 4],
@@ -251,7 +251,7 @@ class ServiceTest extends TestCase
         $this->assertEquals('integer', $param['type']);
     }
 
-    public function testSetparamsShouldOverwriteExistingParams()
+    public function testSetparamsShouldOverwriteExistingParams() : void
     {
         $this->testShouldBeAbleToAddMultipleParamsAtOnce();
         $params = $this->service->getParams();
@@ -266,19 +266,19 @@ class ServiceTest extends TestCase
         $this->assertCount(2, $test);
     }
 
-    public function testReturnShouldBeNullByDefault()
+    public function testReturnShouldBeNullByDefault() : void
     {
         $this->assertNull($this->service->getReturn());
     }
 
-    public function testReturnAccessorsShouldWorkWithNormalInput()
+    public function testReturnAccessorsShouldWorkWithNormalInput() : void
     {
         $this->testReturnShouldBeNullByDefault();
         $this->service->setReturn('integer');
         $this->assertEquals('integer', $this->service->getReturn());
     }
 
-    public function testReturnAccessorsShouldAllowArrayOfTypes()
+    public function testReturnAccessorsShouldAllowArrayOfTypes() : void
     {
         $this->testReturnShouldBeNullByDefault();
         $type = ['integer', 'string'];
@@ -286,21 +286,21 @@ class ServiceTest extends TestCase
         $this->assertEquals($type, $this->service->getReturn());
     }
 
-    public function testInvalidReturnTypeShouldThrowException()
+    public function testInvalidReturnTypeShouldThrowException() : void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid param type');
         $this->service->setReturn(new stdClass);
     }
 
-    public function testToArrayShouldCreateSmdCompatibleHash()
+    public function testToArrayShouldCreateSmdCompatibleHash() : void
     {
         $this->setupSmdValidationObject();
         $smd = $this->service->toArray();
         $this->validateSmdArray($smd);
     }
 
-    public function testTojsonShouldEmitJSON()
+    public function testTojsonShouldEmitJSON() : void
     {
         $this->setupSmdValidationObject();
         $json = $this->service->toJSON();
@@ -312,7 +312,7 @@ class ServiceTest extends TestCase
         $this->validateSmdArray($smd['foo']);
     }
 
-    public function setupSmdValidationObject()
+    public function setupSmdValidationObject() : void
     {
         $this->service->setName('foo')
                       ->setTransport('POST')
@@ -324,7 +324,7 @@ class ServiceTest extends TestCase
                       ->setReturn('boolean');
     }
 
-    public function validateSmdArray(array $smd)
+    public function validateSmdArray(array $smd) : void
     {
         $this->assertArrayHasKey('transport', $smd);
         $this->assertEquals('POST', $smd['transport']);

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -67,7 +67,7 @@ class ServiceTest extends TestCase
         $this->service->setName('rpc.Foo');
     }
 
-    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar() : void
+    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar() : void
     {
         $this->service->setName('rpcFoo');
         $this->assertEquals('rpcFoo', $this->service->getName());

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -34,18 +34,18 @@ class SmdTest extends TestCase
         $this->smd = new Smd();
     }
 
-    public function testTransportShouldDefaultToPost()
+    public function testTransportShouldDefaultToPost() : void
     {
         $this->assertEquals('POST', $this->smd->getTransport());
     }
 
-    public function testTransportAccessorsShouldWorkUnderNormalInput()
+    public function testTransportAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->smd->setTransport('POST');
         $this->assertEquals('POST', $this->smd->getTransport());
     }
 
-    public function testTransportShouldBeLimitedToPost()
+    public function testTransportShouldBeLimitedToPost() : void
     {
         foreach (['GET', 'REST'] as $transport) {
             try {
@@ -57,12 +57,12 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testEnvelopeShouldDefaultToJSONRpcVersion1()
+    public function testEnvelopeShouldDefaultToJSONRpcVersion1() : void
     {
         $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
-    public function testEnvelopeAccessorsShouldWorkUnderNormalInput()
+    public function testEnvelopeAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->testEnvelopeShouldDefaultToJSONRpcVersion1();
         $this->smd->setEnvelope(Smd::ENV_JSONRPC_2);
@@ -71,7 +71,7 @@ class SmdTest extends TestCase
         $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
-    public function testEnvelopeShouldBeLimitedToJSONRpcVersions()
+    public function testEnvelopeShouldBeLimitedToJSONRpcVersions() : void
     {
         foreach (['URL', 'PATH', 'JSON'] as $env) {
             try {
@@ -83,12 +83,12 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testContentTypeShouldDefaultToApplicationJSON()
+    public function testContentTypeShouldDefaultToApplicationJSON() : void
     {
         $this->assertEquals('application/json', $this->smd->getContentType());
     }
 
-    public function testContentTypeAccessorsShouldWorkUnderNormalInput()
+    public function testContentTypeAccessorsShouldWorkUnderNormalInput() : void
     {
         foreach (['text/json', 'text/plain', 'application/x-json'] as $type) {
             $this->smd->setContentType($type);
@@ -96,7 +96,7 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testContentTypeShouldBeLimitedToMimeFormatStrings()
+    public function testContentTypeShouldBeLimitedToMimeFormatStrings() : void
     {
         foreach (['plain', 'json', 'foobar'] as $type) {
             try {
@@ -108,48 +108,48 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testTargetShouldDefaultToNull()
+    public function testTargetShouldDefaultToNull() : void
     {
         $this->assertNull($this->smd->getTarget());
     }
 
-    public function testTargetAccessorsShouldWorkUnderNormalInput()
+    public function testTargetAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->testTargetShouldDefaultToNull();
         $this->smd->setTarget('foo');
         $this->assertEquals('foo', $this->smd->getTarget());
     }
 
-    public function testIdShouldDefaultToNull()
+    public function testIdShouldDefaultToNull() : void
     {
         $this->assertNull($this->smd->getId());
     }
 
-    public function testIdAccessorsShouldWorkUnderNormalInput()
+    public function testIdAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->testIdShouldDefaultToNull();
         $this->smd->setId('foo');
         $this->assertEquals('foo', $this->smd->getId());
     }
 
-    public function testDescriptionShouldDefaultToNull()
+    public function testDescriptionShouldDefaultToNull() : void
     {
         $this->assertNull($this->smd->getDescription());
     }
 
-    public function testDescriptionAccessorsShouldWorkUnderNormalInput()
+    public function testDescriptionAccessorsShouldWorkUnderNormalInput() : void
     {
         $this->testDescriptionShouldDefaultToNull();
         $this->smd->setDescription('foo');
         $this->assertEquals('foo', $this->smd->getDescription());
     }
 
-    public function testDojoCompatibilityShouldBeDisabledByDefault()
+    public function testDojoCompatibilityShouldBeDisabledByDefault() : void
     {
         $this->assertFalse($this->smd->isDojoCompatible());
     }
 
-    public function testDojoCompatibilityFlagShouldBeMutable()
+    public function testDojoCompatibilityFlagShouldBeMutable() : void
     {
         $this->testDojoCompatibilityShouldBeDisabledByDefault();
         $this->smd->setDojoCompatible(true);
@@ -158,21 +158,21 @@ class SmdTest extends TestCase
         $this->assertFalse($this->smd->isDojoCompatible());
     }
 
-    public function testServicesShouldBeEmptyByDefault()
+    public function testServicesShouldBeEmptyByDefault() : void
     {
         $services = $this->smd->getServices();
         $this->assertIsArray($services);
         $this->assertEmpty($services);
     }
 
-    public function testShouldBeAbleToUseServiceObjectToAddService()
+    public function testShouldBeAbleToUseServiceObjectToAddService() : void
     {
         $service = new Smd\Service('foo');
         $this->smd->addService($service);
         $this->assertSame($service, $this->smd->getService('foo'));
     }
 
-    public function testShouldBeAbleToUseArrayToAddService()
+    public function testShouldBeAbleToUseArrayToAddService() : void
     {
         $service = [
             'name' => 'foo',
@@ -183,7 +183,7 @@ class SmdTest extends TestCase
         $this->assertEquals('foo', $foo->getName());
     }
 
-    public function testAddingServiceWithExistingServiceNameShouldThrowException()
+    public function testAddingServiceWithExistingServiceNameShouldThrowException() : void
     {
         $service = new Smd\Service('foo');
         $this->smd->addService($service);
@@ -196,7 +196,7 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testAttemptingToRegisterInvalidServiceShouldThrowException()
+    public function testAttemptingToRegisterInvalidServiceShouldThrowException() : void
     {
         foreach (['foo', false, 1, 1.0] as $service) {
             try {
@@ -208,7 +208,7 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfServiceObjects()
+    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfServiceObjects() : void
     {
         $one   = new Smd\Service('one');
         $two   = new Smd\Service('two');
@@ -219,7 +219,7 @@ class SmdTest extends TestCase
         $this->assertSame($services, array_values($test));
     }
 
-    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfArrays()
+    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfArrays() : void
     {
         $services = [
             ['name' => 'one'],
@@ -231,7 +231,7 @@ class SmdTest extends TestCase
         $this->assertSame(['one', 'two', 'three'], array_keys($test));
     }
 
-    public function testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays()
+    public function testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays() : void
     {
         $two = new Smd\Service('two');
         $services = [
@@ -245,7 +245,7 @@ class SmdTest extends TestCase
         $this->assertEquals($two, $test['two']);
     }
 
-    public function testSetServicesShouldOverwriteExistingServices()
+    public function testSetServicesShouldOverwriteExistingServices() : void
     {
         $this->testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays();
         $five = new Smd\Service('five');
@@ -260,19 +260,19 @@ class SmdTest extends TestCase
         $this->assertEquals($five, $test['five']);
     }
 
-    public function testShouldBeAbleToRetrieveServiceByName()
+    public function testShouldBeAbleToRetrieveServiceByName() : void
     {
         $this->testShouldBeAbleToUseServiceObjectToAddService();
     }
 
-    public function testShouldBeAbleToRemoveServiceByName()
+    public function testShouldBeAbleToRemoveServiceByName() : void
     {
         $this->testShouldBeAbleToUseServiceObjectToAddService();
         $this->assertTrue($this->smd->removeService('foo'));
         $this->assertFalse($this->smd->getService('foo'));
     }
 
-    public function testShouldBeAbleToCastToArray()
+    public function testShouldBeAbleToCastToArray() : void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -280,7 +280,7 @@ class SmdTest extends TestCase
         $this->validateServiceArray($service, $options);
     }
 
-    public function testShouldBeAbleToCastToDojoArray()
+    public function testShouldBeAbleToCastToDojoArray() : void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -316,7 +316,7 @@ class SmdTest extends TestCase
         $this->assertCount(1, $bar['parameters']);
     }
 
-    public function testShouldBeAbleToRenderAsJSON()
+    public function testShouldBeAbleToRenderAsJSON() : void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -325,7 +325,7 @@ class SmdTest extends TestCase
         $this->validateServiceArray($smd, $options);
     }
 
-    public function testToStringImplementationShouldProxyToJSON()
+    public function testToStringImplementationShouldProxyToJSON() : void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -334,7 +334,7 @@ class SmdTest extends TestCase
         $this->validateServiceArray($smd, $options);
     }
 
-    public function getOptions()
+    public function getOptions() : array
     {
         return [
             'target'   => '/test/me',
@@ -358,7 +358,7 @@ class SmdTest extends TestCase
         ];
     }
 
-    public function validateServiceArray(array $smd, array $options)
+    public function validateServiceArray(array $smd, array $options) : void
     {
         $this->assertIsArray($smd);
 
@@ -385,7 +385,7 @@ class SmdTest extends TestCase
     /**
      * @group Laminas-5624
      */
-    public function testSetOptionsShouldAccommodateToArrayOutput()
+    public function testSetOptionsShouldAccommodateToArrayOutput() : void
     {
         $smdSource = new Smd();
         $smdSource->setContentType('application/json');

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -37,13 +37,13 @@ class SmdTest extends TestCase
 
     public function testTransportShouldDefaultToPost(): void
     {
-        $this->assertEquals('POST', $this->smd->getTransport());
+        $this->assertSame('POST', $this->smd->getTransport());
     }
 
     public function testTransportAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->smd->setTransport('POST');
-        $this->assertEquals('POST', $this->smd->getTransport());
+        $this->assertSame('POST', $this->smd->getTransport());
     }
 
     public function testTransportShouldBeLimitedToPost(): void
@@ -60,16 +60,16 @@ class SmdTest extends TestCase
 
     public function testEnvelopeShouldDefaultToJSONRpcVersion1(): void
     {
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
+        $this->assertSame(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
     public function testEnvelopeAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testEnvelopeShouldDefaultToJSONRpcVersion1();
         $this->smd->setEnvelope(Smd::ENV_JSONRPC_2);
-        $this->assertEquals(Smd::ENV_JSONRPC_2, $this->smd->getEnvelope());
+        $this->assertSame(Smd::ENV_JSONRPC_2, $this->smd->getEnvelope());
         $this->smd->setEnvelope(Smd::ENV_JSONRPC_1);
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
+        $this->assertSame(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
     public function testEnvelopeShouldBeLimitedToJSONRpcVersions(): void
@@ -86,14 +86,14 @@ class SmdTest extends TestCase
 
     public function testContentTypeShouldDefaultToApplicationJSON(): void
     {
-        $this->assertEquals('application/json', $this->smd->getContentType());
+        $this->assertSame('application/json', $this->smd->getContentType());
     }
 
     public function testContentTypeAccessorsShouldWorkUnderNormalInput(): void
     {
         foreach (['text/json', 'text/plain', 'application/x-json'] as $type) {
             $this->smd->setContentType($type);
-            $this->assertEquals($type, $this->smd->getContentType());
+            $this->assertSame($type, $this->smd->getContentType());
         }
     }
 
@@ -111,38 +111,38 @@ class SmdTest extends TestCase
 
     public function testTargetShouldDefaultToAnEmptyString(): void
     {
-        $this->assertEquals('', $this->smd->getTarget());
+        $this->assertSame('', $this->smd->getTarget());
     }
 
     public function testTargetAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testTargetShouldDefaultToAnEmptyString();
         $this->smd->setTarget('foo');
-        $this->assertEquals('foo', $this->smd->getTarget());
+        $this->assertSame('foo', $this->smd->getTarget());
     }
 
     public function testIdShouldDefaultToAnEmptyString(): void
     {
-        $this->assertEquals('', $this->smd->getId());
+        $this->assertSame('', $this->smd->getId());
     }
 
     public function testIdAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testIdShouldDefaultToAnEmptyString();
         $this->smd->setId('foo');
-        $this->assertEquals('foo', $this->smd->getId());
+        $this->assertSame('foo', $this->smd->getId());
     }
 
     public function testDescriptionShouldDefaultToAnEmptyString(): void
     {
-        $this->assertEquals('', $this->smd->getDescription());
+        $this->assertSame('', $this->smd->getDescription());
     }
 
     public function testDescriptionAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testDescriptionShouldDefaultToAnEmptyString();
         $this->smd->setDescription('foo');
-        $this->assertEquals('foo', $this->smd->getDescription());
+        $this->assertSame('foo', $this->smd->getDescription());
     }
 
     public function testDojoCompatibilityShouldBeDisabledByDefault(): void
@@ -181,7 +181,7 @@ class SmdTest extends TestCase
         $this->smd->addService($service);
         $foo = $this->smd->getService('foo');
         $this->assertInstanceOf(Service::class, $foo);
-        $this->assertEquals('foo', $foo->getName());
+        $this->assertSame('foo', $foo->getName());
     }
 
     public function testAddingServiceWithExistingServiceNameShouldThrowException(): void
@@ -243,7 +243,7 @@ class SmdTest extends TestCase
         $this->smd->addServices($services);
         $test = $this->smd->getServices();
         $this->assertSame(['one', 'two', 'three'], array_keys($test));
-        $this->assertEquals($two, $test['two']);
+        $this->assertSame($two, $test['two']);
     }
 
     public function testSetServicesShouldOverwriteExistingServices(): void
@@ -258,7 +258,7 @@ class SmdTest extends TestCase
         $this->smd->setServices($services);
         $test = $this->smd->getServices();
         $this->assertSame(['four', 'five', 'six'], array_keys($test));
-        $this->assertEquals($five, $test['five']);
+        $this->assertSame($five, $test['five']);
     }
 
     public function testShouldBeAbleToRetrieveServiceByName(): void
@@ -293,8 +293,8 @@ class SmdTest extends TestCase
         $this->assertArrayHasKey('serviceType', $smd);
         $this->assertArrayHasKey('methods', $smd);
 
-        $this->assertEquals('.1', $smd['SMDVersion']);
-        $this->assertEquals('JSON-RPC', $smd['serviceType']);
+        $this->assertSame('.1', $smd['SMDVersion']);
+        $this->assertSame('JSON-RPC', $smd['serviceType']);
         $methods = $smd['methods'];
         $this->assertCount(2, $methods);
 
@@ -302,8 +302,8 @@ class SmdTest extends TestCase
         $this->assertArrayHasKey('name', $foo);
         $this->assertArrayHasKey('serviceURL', $foo);
         $this->assertArrayHasKey('parameters', $foo);
-        $this->assertEquals('foo', $foo['name']);
-        $this->assertEquals($this->smd->getTarget(), $foo['serviceURL']);
+        $this->assertSame('foo', $foo['name']);
+        $this->assertSame($this->smd->getTarget(), $foo['serviceURL']);
         $this->assertIsArray($foo['parameters']);
         $this->assertCount(1, $foo['parameters']);
 
@@ -311,8 +311,8 @@ class SmdTest extends TestCase
         $this->assertArrayHasKey('name', $bar);
         $this->assertArrayHasKey('serviceURL', $bar);
         $this->assertArrayHasKey('parameters', $bar);
-        $this->assertEquals('bar', $bar['name']);
-        $this->assertEquals($this->smd->getTarget(), $bar['serviceURL']);
+        $this->assertSame('bar', $bar['name']);
+        $this->assertSame($this->smd->getTarget(), $bar['serviceURL']);
         $this->assertIsArray($bar['parameters']);
         $this->assertCount(1, $bar['parameters']);
     }
@@ -371,12 +371,12 @@ class SmdTest extends TestCase
         $this->assertArrayHasKey('contentType', $smd);
         $this->assertArrayHasKey('services', $smd);
 
-        $this->assertEquals(Smd::SMD_VERSION, $smd['SMDVersion']);
-        $this->assertEquals($options['target'], $smd['target']);
-        $this->assertEquals($options['id'], $smd['id']);
-        $this->assertEquals($this->smd->getTransport(), $smd['transport']);
-        $this->assertEquals($this->smd->getEnvelope(), $smd['envelope']);
-        $this->assertEquals($this->smd->getContentType(), $smd['contentType']);
+        $this->assertSame(Smd::SMD_VERSION, $smd['SMDVersion']);
+        $this->assertSame($options['target'], $smd['target']);
+        $this->assertSame($options['id'], $smd['id']);
+        $this->assertSame($this->smd->getTransport(), $smd['transport']);
+        $this->assertSame($this->smd->getEnvelope(), $smd['envelope']);
+        $this->assertSame($this->smd->getContentType(), $smd['contentType']);
         $services = $smd['services'];
         $this->assertCount(2, $services);
         $this->assertArrayHasKey('foo', $services);
@@ -405,27 +405,27 @@ class SmdTest extends TestCase
         // ... : SMD service description requires a name; none provided
         $smdDestination->setOptions($smdSource->toArray());
 
-        $this->assertEquals(
+        $this->assertSame(
             $smdSource->getContentType(),
             $smdDestination->getContentType()
         );
-        $this->assertEquals(
+        $this->assertSame(
             $smdSource->getDescription(),
             $smdDestination->getDescription()
         );
-        $this->assertEquals(
+        $this->assertSame(
             $smdSource->getEnvelope(),
             $smdDestination->getEnvelope()
         );
-        $this->assertEquals(
+        $this->assertSame(
             $smdSource->getId(),
             $smdDestination->getId()
         );
-        $this->assertEquals(
+        $this->assertSame(
             $smdSource->getTarget(),
             $smdDestination->getTarget()
         );
-        $this->assertEquals(
+        $this->assertSame(
             $smdSource->getTransport(),
             $smdDestination->getTransport()
         );

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json;

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -10,10 +10,11 @@ declare(strict_types=1);
 
 namespace LaminasTest\Json\Server;
 
-use Laminas\Json;
+use Laminas\Json\Json;
 use Laminas\Json\Server\Exception\InvalidArgumentException;
 use Laminas\Json\Server\Exception\RuntimeException;
 use Laminas\Json\Server\Smd;
+use Laminas\Json\Server\Smd\Service;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
@@ -108,38 +109,38 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testTargetShouldDefaultToNull() : void
+    public function testTargetShouldDefaultToAnEmptyString() : void
     {
-        $this->assertNull($this->smd->getTarget());
+        $this->assertEquals('', $this->smd->getTarget());
     }
 
     public function testTargetAccessorsShouldWorkUnderNormalInput() : void
     {
-        $this->testTargetShouldDefaultToNull();
+        $this->testTargetShouldDefaultToAnEmptyString();
         $this->smd->setTarget('foo');
         $this->assertEquals('foo', $this->smd->getTarget());
     }
 
-    public function testIdShouldDefaultToNull() : void
+    public function testIdShouldDefaultToAnEmptyString() : void
     {
-        $this->assertNull($this->smd->getId());
+        $this->assertEquals('', $this->smd->getId());
     }
 
     public function testIdAccessorsShouldWorkUnderNormalInput() : void
     {
-        $this->testIdShouldDefaultToNull();
+        $this->testIdShouldDefaultToAnEmptyString();
         $this->smd->setId('foo');
         $this->assertEquals('foo', $this->smd->getId());
     }
 
-    public function testDescriptionShouldDefaultToNull() : void
+    public function testDescriptionShouldDefaultToAnEmptyString() : void
     {
-        $this->assertNull($this->smd->getDescription());
+        $this->assertEquals('', $this->smd->getDescription());
     }
 
     public function testDescriptionAccessorsShouldWorkUnderNormalInput() : void
     {
-        $this->testDescriptionShouldDefaultToNull();
+        $this->testDescriptionShouldDefaultToAnEmptyString();
         $this->smd->setDescription('foo');
         $this->assertEquals('foo', $this->smd->getDescription());
     }
@@ -179,7 +180,7 @@ class SmdTest extends TestCase
         ];
         $this->smd->addService($service);
         $foo = $this->smd->getService('foo');
-        $this->assertInstanceOf(Json::class, $foo);
+        $this->assertInstanceOf(Service::class, $foo);
         $this->assertEquals('foo', $foo->getName());
     }
 
@@ -321,7 +322,7 @@ class SmdTest extends TestCase
         $options = $this->getOptions();
         $this->smd->setOptions($options);
         $json = $this->smd->toJSON();
-        $smd  = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
+        $smd  = Json::decode($json, Json::TYPE_ARRAY);
         $this->validateServiceArray($smd, $options);
     }
 
@@ -330,7 +331,7 @@ class SmdTest extends TestCase
         $options = $this->getOptions();
         $this->smd->setOptions($options);
         $json = $this->smd->__toString();
-        $smd  = Json\Json::decode($json, Json\Json::TYPE_ARRAY);
+        $smd  = Json::decode($json, Json::TYPE_ARRAY);
         $this->validateServiceArray($smd, $options);
     }
 

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -16,6 +16,11 @@ use Laminas\Json\Server\Exception\RuntimeException;
 use Laminas\Json\Server\Smd;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
+use function array_shift;
+use function array_values;
+use function uniqid;
+
 class SmdTest extends TestCase
 {
     /**
@@ -174,7 +179,7 @@ class SmdTest extends TestCase
         ];
         $this->smd->addService($service);
         $foo = $this->smd->getService('foo');
-        $this->assertInstanceOf('Laminas\Json\Server\Smd\Service', $foo);
+        $this->assertInstanceOf(Json::class, $foo);
         $this->assertEquals('foo', $foo->getName());
     }
 
@@ -390,7 +395,7 @@ class SmdTest extends TestCase
         $smdSource->setTarget('http://foo');
         $smdSource->setTransport('POST');
         $smdSource->setServices([
-            ['name' => 'foo']
+            ['name' => 'foo'],
         ]);
 
         $smdDestination = new Smd();

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -30,23 +30,23 @@ class SmdTest extends TestCase
      *
      * @return void
      */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->smd = new Smd();
     }
 
-    public function testTransportShouldDefaultToPost() : void
+    public function testTransportShouldDefaultToPost(): void
     {
         $this->assertEquals('POST', $this->smd->getTransport());
     }
 
-    public function testTransportAccessorsShouldWorkUnderNormalInput() : void
+    public function testTransportAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->smd->setTransport('POST');
         $this->assertEquals('POST', $this->smd->getTransport());
     }
 
-    public function testTransportShouldBeLimitedToPost() : void
+    public function testTransportShouldBeLimitedToPost(): void
     {
         foreach (['GET', 'REST'] as $transport) {
             try {
@@ -58,12 +58,12 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testEnvelopeShouldDefaultToJSONRpcVersion1() : void
+    public function testEnvelopeShouldDefaultToJSONRpcVersion1(): void
     {
         $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
-    public function testEnvelopeAccessorsShouldWorkUnderNormalInput() : void
+    public function testEnvelopeAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testEnvelopeShouldDefaultToJSONRpcVersion1();
         $this->smd->setEnvelope(Smd::ENV_JSONRPC_2);
@@ -72,7 +72,7 @@ class SmdTest extends TestCase
         $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
-    public function testEnvelopeShouldBeLimitedToJSONRpcVersions() : void
+    public function testEnvelopeShouldBeLimitedToJSONRpcVersions(): void
     {
         foreach (['URL', 'PATH', 'JSON'] as $env) {
             try {
@@ -84,12 +84,12 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testContentTypeShouldDefaultToApplicationJSON() : void
+    public function testContentTypeShouldDefaultToApplicationJSON(): void
     {
         $this->assertEquals('application/json', $this->smd->getContentType());
     }
 
-    public function testContentTypeAccessorsShouldWorkUnderNormalInput() : void
+    public function testContentTypeAccessorsShouldWorkUnderNormalInput(): void
     {
         foreach (['text/json', 'text/plain', 'application/x-json'] as $type) {
             $this->smd->setContentType($type);
@@ -97,7 +97,7 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testContentTypeShouldBeLimitedToMimeFormatStrings() : void
+    public function testContentTypeShouldBeLimitedToMimeFormatStrings(): void
     {
         foreach (['plain', 'json', 'foobar'] as $type) {
             try {
@@ -109,48 +109,48 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testTargetShouldDefaultToAnEmptyString() : void
+    public function testTargetShouldDefaultToAnEmptyString(): void
     {
         $this->assertEquals('', $this->smd->getTarget());
     }
 
-    public function testTargetAccessorsShouldWorkUnderNormalInput() : void
+    public function testTargetAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testTargetShouldDefaultToAnEmptyString();
         $this->smd->setTarget('foo');
         $this->assertEquals('foo', $this->smd->getTarget());
     }
 
-    public function testIdShouldDefaultToAnEmptyString() : void
+    public function testIdShouldDefaultToAnEmptyString(): void
     {
         $this->assertEquals('', $this->smd->getId());
     }
 
-    public function testIdAccessorsShouldWorkUnderNormalInput() : void
+    public function testIdAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testIdShouldDefaultToAnEmptyString();
         $this->smd->setId('foo');
         $this->assertEquals('foo', $this->smd->getId());
     }
 
-    public function testDescriptionShouldDefaultToAnEmptyString() : void
+    public function testDescriptionShouldDefaultToAnEmptyString(): void
     {
         $this->assertEquals('', $this->smd->getDescription());
     }
 
-    public function testDescriptionAccessorsShouldWorkUnderNormalInput() : void
+    public function testDescriptionAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testDescriptionShouldDefaultToAnEmptyString();
         $this->smd->setDescription('foo');
         $this->assertEquals('foo', $this->smd->getDescription());
     }
 
-    public function testDojoCompatibilityShouldBeDisabledByDefault() : void
+    public function testDojoCompatibilityShouldBeDisabledByDefault(): void
     {
         $this->assertFalse($this->smd->isDojoCompatible());
     }
 
-    public function testDojoCompatibilityFlagShouldBeMutable() : void
+    public function testDojoCompatibilityFlagShouldBeMutable(): void
     {
         $this->testDojoCompatibilityShouldBeDisabledByDefault();
         $this->smd->setDojoCompatible(true);
@@ -159,21 +159,21 @@ class SmdTest extends TestCase
         $this->assertFalse($this->smd->isDojoCompatible());
     }
 
-    public function testServicesShouldBeEmptyByDefault() : void
+    public function testServicesShouldBeEmptyByDefault(): void
     {
         $services = $this->smd->getServices();
         $this->assertIsArray($services);
         $this->assertEmpty($services);
     }
 
-    public function testShouldBeAbleToUseServiceObjectToAddService() : void
+    public function testShouldBeAbleToUseServiceObjectToAddService(): void
     {
         $service = new Smd\Service('foo');
         $this->smd->addService($service);
         $this->assertSame($service, $this->smd->getService('foo'));
     }
 
-    public function testShouldBeAbleToUseArrayToAddService() : void
+    public function testShouldBeAbleToUseArrayToAddService(): void
     {
         $service = [
             'name' => 'foo',
@@ -184,7 +184,7 @@ class SmdTest extends TestCase
         $this->assertEquals('foo', $foo->getName());
     }
 
-    public function testAddingServiceWithExistingServiceNameShouldThrowException() : void
+    public function testAddingServiceWithExistingServiceNameShouldThrowException(): void
     {
         $service = new Smd\Service('foo');
         $this->smd->addService($service);
@@ -197,7 +197,7 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testAttemptingToRegisterInvalidServiceShouldThrowException() : void
+    public function testAttemptingToRegisterInvalidServiceShouldThrowException(): void
     {
         foreach (['foo', false, 1, 1.0] as $service) {
             try {
@@ -209,7 +209,7 @@ class SmdTest extends TestCase
         }
     }
 
-    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfServiceObjects() : void
+    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfServiceObjects(): void
     {
         $one   = new Smd\Service('one');
         $two   = new Smd\Service('two');
@@ -220,7 +220,7 @@ class SmdTest extends TestCase
         $this->assertSame($services, array_values($test));
     }
 
-    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfArrays() : void
+    public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfArrays(): void
     {
         $services = [
             ['name' => 'one'],
@@ -232,7 +232,7 @@ class SmdTest extends TestCase
         $this->assertSame(['one', 'two', 'three'], array_keys($test));
     }
 
-    public function testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays() : void
+    public function testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays(): void
     {
         $two = new Smd\Service('two');
         $services = [
@@ -246,7 +246,7 @@ class SmdTest extends TestCase
         $this->assertEquals($two, $test['two']);
     }
 
-    public function testSetServicesShouldOverwriteExistingServices() : void
+    public function testSetServicesShouldOverwriteExistingServices(): void
     {
         $this->testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays();
         $five = new Smd\Service('five');
@@ -261,19 +261,19 @@ class SmdTest extends TestCase
         $this->assertEquals($five, $test['five']);
     }
 
-    public function testShouldBeAbleToRetrieveServiceByName() : void
+    public function testShouldBeAbleToRetrieveServiceByName(): void
     {
         $this->testShouldBeAbleToUseServiceObjectToAddService();
     }
 
-    public function testShouldBeAbleToRemoveServiceByName() : void
+    public function testShouldBeAbleToRemoveServiceByName(): void
     {
         $this->testShouldBeAbleToUseServiceObjectToAddService();
         $this->assertTrue($this->smd->removeService('foo'));
         $this->assertFalse($this->smd->getService('foo'));
     }
 
-    public function testShouldBeAbleToCastToArray() : void
+    public function testShouldBeAbleToCastToArray(): void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -281,7 +281,7 @@ class SmdTest extends TestCase
         $this->validateServiceArray($service, $options);
     }
 
-    public function testShouldBeAbleToCastToDojoArray() : void
+    public function testShouldBeAbleToCastToDojoArray(): void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -317,7 +317,7 @@ class SmdTest extends TestCase
         $this->assertCount(1, $bar['parameters']);
     }
 
-    public function testShouldBeAbleToRenderAsJSON() : void
+    public function testShouldBeAbleToRenderAsJSON(): void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -326,7 +326,7 @@ class SmdTest extends TestCase
         $this->validateServiceArray($smd, $options);
     }
 
-    public function testToStringImplementationShouldProxyToJSON() : void
+    public function testToStringImplementationShouldProxyToJSON(): void
     {
         $options = $this->getOptions();
         $this->smd->setOptions($options);
@@ -335,7 +335,7 @@ class SmdTest extends TestCase
         $this->validateServiceArray($smd, $options);
     }
 
-    public function getOptions() : array
+    public function getOptions(): array
     {
         return [
             'target'   => '/test/me',
@@ -359,7 +359,7 @@ class SmdTest extends TestCase
         ];
     }
 
-    public function validateServiceArray(array $smd, array $options) : void
+    public function validateServiceArray(array $smd, array $options): void
     {
         $this->assertIsArray($smd);
 
@@ -386,7 +386,7 @@ class SmdTest extends TestCase
     /**
      * @group Laminas-5624
      */
-    public function testSetOptionsShouldAccommodateToArrayOutput() : void
+    public function testSetOptionsShouldAccommodateToArrayOutput(): void
     {
         $smdSource = new Smd();
         $smdSource->setContentType('application/json');

--- a/test/TestAsset/Bar.php
+++ b/test/TestAsset/Bar.php
@@ -29,7 +29,7 @@ class Bar
      * @param  mixed $three
      * @return array
      */
-    public function foo($one, $two = 'two', $three = null)
+    public function foo($one, $two = 'two', $three = null) : array
     {
         return [$one, $two, $three, $this->val];
     }
@@ -39,7 +39,7 @@ class Bar
      *
      * @return void
      */
-    public function baz()
+    public function baz() : void
     {
         throw new Exception('application error');
     }

--- a/test/TestAsset/Bar.php
+++ b/test/TestAsset/Bar.php
@@ -29,7 +29,7 @@ class Bar
      * @param  mixed $three
      * @return array
      */
-    public function foo($one, $two = 'two', $three = null) : array
+    public function foo(bool $one, string $two = 'two', $three = null) : array
     {
         return [$one, $two, $three, $this->val];
     }

--- a/test/TestAsset/Bar.php
+++ b/test/TestAsset/Bar.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use Exception;

--- a/test/TestAsset/Bar.php
+++ b/test/TestAsset/Bar.php
@@ -29,7 +29,7 @@ class Bar
      * @param  mixed $three
      * @return array
      */
-    public function foo(bool $one, string $two = 'two', $three = null) : array
+    public function foo(bool $one, string $two = 'two', $three = null): array
     {
         return [$one, $two, $three, $this->val];
     }
@@ -39,7 +39,7 @@ class Bar
      *
      * @return void
      */
-    public function baz() : void
+    public function baz(): void
     {
         throw new Exception('application error');
     }

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -25,7 +25,7 @@ class Foo
      * @param  mixed $three
      * @return array
      */
-    public function bar(bool $one, string $two = 'two', $three = null) : array
+    public function bar(bool $one, string $two = 'two', $three = null): array
     {
         return [$one, $two, $three];
     }
@@ -35,7 +35,7 @@ class Foo
      *
      * @return void
      */
-    public function baz() : void
+    public function baz(): void
     {
         throw new Exception('application error');
     }

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -25,7 +25,7 @@ class Foo
      * @param  mixed $three
      * @return array
      */
-    public function bar($one, $two = 'two', $three = null)
+    public function bar($one, $two = 'two', $three = null) : array
     {
         return [$one, $two, $three];
     }
@@ -35,7 +35,7 @@ class Foo
      *
      * @return void
      */
-    public function baz()
+    public function baz() : void
     {
         throw new Exception('application error');
     }

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use Exception;

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -25,7 +25,7 @@ class Foo
      * @param  mixed $three
      * @return array
      */
-    public function bar($one, $two = 'two', $three = null) : array
+    public function bar(bool $one, string $two = 'two', $three = null) : array
     {
         return [$one, $two, $three];
     }

--- a/test/TestAsset/FooFunc.php
+++ b/test/TestAsset/FooFunc.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 /**

--- a/test/TestAsset/FooFunc.php
+++ b/test/TestAsset/FooFunc.php
@@ -15,7 +15,7 @@ namespace LaminasTest\Json\Server\TestAsset;
  *
  * @return bool
  */
-function FooFunc()
+function FooFunc() : bool
 {
     return true;
 }

--- a/test/TestAsset/FooFunc.php
+++ b/test/TestAsset/FooFunc.php
@@ -15,7 +15,7 @@ namespace LaminasTest\Json\Server\TestAsset;
  *
  * @return bool
  */
-function FooFunc() : bool
+function FooFunc(): bool
 {
     return true;
 }

--- a/test/TestAsset/FooParameters.php
+++ b/test/TestAsset/FooParameters.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 /**

--- a/test/TestAsset/FooParameters.php
+++ b/test/TestAsset/FooParameters.php
@@ -22,7 +22,7 @@ class FooParameters
      * @param  string $two
      * @return array
      */
-    public function bar($one, $two)
+    public function bar($one, $two) : array
     {
         return [$one, $two];
     }
@@ -35,7 +35,7 @@ class FooParameters
      * @param  string $three
      * @return array
      */
-    public function baz($one, $two, $three = "default")
+    public function baz($one, $two, $three = "default") : array
     {
         return [$one, $two, $three];
     }

--- a/test/TestAsset/FooParameters.php
+++ b/test/TestAsset/FooParameters.php
@@ -22,7 +22,7 @@ class FooParameters
      * @param  string $two
      * @return array
      */
-    public function bar(bool $one, string $two) : array
+    public function bar(bool $one, string $two): array
     {
         return [$one, $two];
     }
@@ -35,7 +35,7 @@ class FooParameters
      * @param  string $three
      * @return array
      */
-    public function baz(bool $one, string $two, string $three = "default") : array
+    public function baz(bool $one, string $two, string $three = "default"): array
     {
         return [$one, $two, $three];
     }

--- a/test/TestAsset/FooParameters.php
+++ b/test/TestAsset/FooParameters.php
@@ -22,7 +22,7 @@ class FooParameters
      * @param  string $two
      * @return array
      */
-    public function bar($one, $two) : array
+    public function bar(bool $one, string $two) : array
     {
         return [$one, $two];
     }
@@ -35,7 +35,7 @@ class FooParameters
      * @param  string $three
      * @return array
      */
-    public function baz($one, $two, $three = "default") : array
+    public function baz(bool $one, string $two, string $three = "default") : array
     {
         return [$one, $two, $three];
     }

--- a/test/TestAsset/JsonSerializableBuiltinImpl.php
+++ b/test/TestAsset/JsonSerializableBuiltinImpl.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use JsonSerializable;

--- a/test/TestAsset/JsonSerializableBuiltinImpl.php
+++ b/test/TestAsset/JsonSerializableBuiltinImpl.php
@@ -17,7 +17,7 @@ use JsonSerializable;
  */
 class JsonSerializableBuiltinImpl implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize() : array
     {
         return [__FUNCTION__];
     }

--- a/test/TestAsset/JsonSerializableBuiltinImpl.php
+++ b/test/TestAsset/JsonSerializableBuiltinImpl.php
@@ -17,7 +17,7 @@ use JsonSerializable;
  */
 class JsonSerializableBuiltinImpl implements JsonSerializable
 {
-    public function jsonSerialize() : array
+    public function jsonSerialize(): array
     {
         return [__FUNCTION__];
     }

--- a/test/TestAsset/JsonSerializableZFImpl.php
+++ b/test/TestAsset/JsonSerializableZFImpl.php
@@ -14,7 +14,7 @@ use Laminas\Stdlib\JsonSerializable;
 
 class JsonSerializableLaminasImpl implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize() : array
     {
         return [__FUNCTION__];
     }

--- a/test/TestAsset/JsonSerializableZFImpl.php
+++ b/test/TestAsset/JsonSerializableZFImpl.php
@@ -14,7 +14,7 @@ use Laminas\Stdlib\JsonSerializable;
 
 class JsonSerializableLaminasImpl implements JsonSerializable
 {
-    public function jsonSerialize() : array
+    public function jsonSerialize(): array
     {
         return [__FUNCTION__];
     }

--- a/test/TestAsset/JsonSerializableZFImpl.php
+++ b/test/TestAsset/JsonSerializableZFImpl.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use Laminas\Stdlib\JsonSerializable;

--- a/test/TestAsset/ServiceA.php
+++ b/test/TestAsset/ServiceA.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-json-server for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-json-server/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Json\Server\TestAsset;
+
+class ServiceA
+{
+    public function hello(string $name): string
+    {
+        return sprintf('Hello %s!', $name);
+    }
+}

--- a/test/TestAsset/ServiceB.php
+++ b/test/TestAsset/ServiceB.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-json-server for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-json-server/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Json\Server\TestAsset;
+
+class ServiceB
+{
+    public function hello(string $name): string
+    {
+        return sprintf('Ciao %s!', $name);
+    }
+}

--- a/test/TestAsset/TestIteratorAggregate.php
+++ b/test/TestAsset/TestIteratorAggregate.php
@@ -6,6 +6,8 @@
  * @license   https://github.com/laminas/laminas-json-server/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use ArrayIterator;

--- a/test/TestAsset/TestIteratorAggregate.php
+++ b/test/TestAsset/TestIteratorAggregate.php
@@ -23,7 +23,7 @@ class TestIteratorAggregate implements IteratorAggregate
         'baz' => 5,
     ];
 
-    public function getIterator() : ArrayIterator
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->array);
     }

--- a/test/TestAsset/TestIteratorAggregate.php
+++ b/test/TestAsset/TestIteratorAggregate.php
@@ -12,6 +12,7 @@ namespace LaminasTest\Json\Server\TestAsset;
 
 use ArrayIterator;
 use IteratorAggregate;
+use Traversable;
 
 /**
  * @see Laminas-12347
@@ -23,7 +24,7 @@ class TestIteratorAggregate implements IteratorAggregate
         'baz' => 5,
     ];
 
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->array);
     }

--- a/test/TestAsset/TestIteratorAggregate.php
+++ b/test/TestAsset/TestIteratorAggregate.php
@@ -23,7 +23,7 @@ class TestIteratorAggregate implements IteratorAggregate
         'baz' => 5,
     ];
 
-    public function getIterator()
+    public function getIterator() : ArrayIterator
     {
         return new ArrayIterator($this->array);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR provides strict typing as described in #2 .

- Add strict type declaration
- Add return type declaration
- Add argument type declaration (where applicable)
- Fix type errors
- Remove tests which are made redundant by type declaration
- Fix second parameter type in calls of `var_export`
