### PR TITLE
Bugfix: Return value of Smd::setDescription()

### DIFF
--- a/src/Smd.php
+++ b/src/Smd.php
@@ -253,7 +253,7 @@ class Smd
     public function setDescription($description)
     {
         $this->description = (string) $description;
-        return $this->description;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fix fluent setter return value of `Smd::setDescription()`.
