### PR TITLE
PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "^2.3",
         "phpunit/phpunit": "^9.5.11",
         "psalm/plugin-phpunit": "^0.16.1",
         "vimeo/psalm": "^4.18.0"

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-http": "^2.15.1",
         "laminas/laminas-json": "^3.3.0",
         "laminas/laminas-server": "^2.11.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de88ec93a083bf1cd91e9714091a4785",
+    "content-hash": "a4f27782748296006d74f4047caf8b06",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -922,12 +922,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Amp\\ByteStream\\": "lib"
-                },
                 "files": [
                     "lib/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1523,9 +1523,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -1533,12 +1530,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4594,13 +4591,13 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Psalm\\": "src/Psalm/"
-                },
                 "files": [
                     "src/functions.php",
                     "src/spl_object_id.php"
-                ]
+                ],
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4739,13 +4736,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.4 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": {
         "ext-json": "*"
     },
-    "platform-overrides": {
-        "php": "7.3.99"
-    },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4680,22 +4680,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.18",
+            "version": "4.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "760baddcea5e0d2ba5bfb882a3243265ad1430d3"
+                "reference": "f82a70e7edfc6cf2705e9374c8a0b6a974a779ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/760baddcea5e0d2ba5bfb882a3243265ad1430d3",
-                "reference": "760baddcea5e0d2ba5bfb882a3243265ad1430d3",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f82a70e7edfc6cf2705e9374c8a0b6a974a779ed",
+                "reference": "f82a70e7edfc6cf2705e9374c8a0b6a974a779ed",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer-runtime-api": "^2.0.0",
+                "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -4728,7 +4728,7 @@
                 "phpmyadmin/sql-parser": "5.1.0||dev-master",
                 "phpspec/prophecy": ">=1.9.0",
                 "phpunit/phpunit": "^9.0",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "psalm/plugin-phpunit": "^0.16",
                 "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3 || ^5.0 || ^6.0",
@@ -4780,9 +4780,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.18"
+                "source": "https://github.com/vimeo/psalm/tree/4.20.0"
             },
-            "time": "2022-01-06T20:49:15+00:00"
+            "time": "2022-02-03T17:03:47+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4f27782748296006d74f4047caf8b06",
+    "content-hash": "956ca41d518c992b214c4842aaa43541",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1258,6 +1258,76 @@
             "time": "2022-01-04T18:29:42+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "v0.1.1",
             "source": {
@@ -1466,31 +1536,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -1504,7 +1579,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2058,6 +2139,55 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
             "time": "2021-12-08T12:19:24+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
+            },
+            "time": "2021-09-16T20:46:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3555,64 +3685,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "7.0.18",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
+                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.0.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.1",
+                "phpstan/phpstan": "1.2.0",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0",
+                "phpstan/phpstan-strict-rules": "1.1.0",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.18"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-12-07T17:19:06+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3625,7 +3789,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -3635,7 +3799,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "symfony/console",
@@ -4619,6 +4783,61 @@
                 "source": "https://github.com/vimeo/psalm/tree/4.18"
             },
             "time": "2022-01-06T20:49:15+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-10-28T21:18:17+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -2509,16 +2509,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.11",
+            "version": "9.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2406855036db1102126125537adb1406f7242fdd"
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2406855036db1102126125537adb1406f7242fdd",
-                "reference": "2406855036db1102126125537adb1406f7242fdd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
                 "shasum": ""
             },
             "require": {
@@ -2596,7 +2596,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
             },
             "funding": [
                 {
@@ -2608,7 +2608,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-25T07:07:57+00:00"
+            "time": "2022-01-24T07:33:35+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -115,9 +115,6 @@
       <code>$error['message']</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$key</code>
-    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="5">
       <code>$errorData</code>
       <code>$response['result']</code>
@@ -163,17 +160,6 @@
     <InvalidParamDefault occurrences="1">
       <code>Request</code>
     </InvalidParamDefault>
-    <InvalidReturnStatement occurrences="6">
-      <code>$params</code>
-      <code>$this-&gt;fault($e-&gt;getMessage(), $e-&gt;getCode(), $e)</code>
-      <code>$this-&gt;fault('Invalid Request', Error::ERROR_INVALID_REQUEST)</code>
-      <code>$this-&gt;fault('Invalid Request', Error::ERROR_INVALID_REQUEST)</code>
-      <code>$this-&gt;fault('Method not found', Error::ERROR_INVALID_METHOD)</code>
-      <code>$this-&gt;fault('Parse error', Error::ERROR_PARSE)</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>void</code>
-    </InvalidReturnType>
     <InvalidScalarArgument occurrences="1">
       <code>$e-&gt;getCode()</code>
     </InvalidScalarArgument>
@@ -192,8 +178,7 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$param['default']</code>
+    <MixedArrayAccess occurrences="2">
       <code>$param['name']</code>
       <code>$param['optional']</code>
     </MixedArrayAccess>
@@ -304,13 +289,7 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$param['name']</code>
-      <code>$param['type']</code>
-      <code>$param['type']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
-      <code>$SMDVersion</code>
+    <MixedAssignment occurrences="6">
       <code>$param</code>
       <code>$service</code>
       <code>$service['services'][$name]</code>
@@ -346,13 +325,6 @@
       <code>! is_string($type) &amp;&amp; ! is_array($type)</code>
       <code>is_string($type)</code>
     </DocblockTypeContradiction>
-    <MissingPropertyType occurrences="5">
-      <code>$envelope</code>
-      <code>$name</code>
-      <code>$return</code>
-      <code>$target</code>
-      <code>$transport</code>
-    </MissingPropertyType>
     <MixedArgument occurrences="5">
       <code>$order</code>
       <code>$paramType</code>
@@ -392,24 +364,13 @@
     <MixedFunctionCall occurrences="1">
       <code>$callback($value)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="6">
+    <MixedInferredReturnType occurrences="1">
       <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string|array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="6">
+    <MixedReturnStatement occurrences="1">
       <code>$paramType</code>
-      <code>$this-&gt;envelope</code>
-      <code>$this-&gt;name</code>
-      <code>$this-&gt;return</code>
-      <code>$this-&gt;target</code>
-      <code>$this-&gt;transport</code>
     </MixedReturnStatement>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(string) $name</code>
+    <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $target</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType occurrences="1">
@@ -428,30 +389,9 @@
     </PossiblyFalseArgument>
   </file>
   <file src="test/ClientTest.php">
-    <ArgumentTypeCoercion occurrences="4">
-      <code>'Laminas\\Http\\Client'</code>
-      <code>'Laminas\\Http\\Client'</code>
-      <code>'Laminas\\Json\\Server\\Request'</code>
-      <code>'Laminas\\Json\\Server\\Response'</code>
-    </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="2">
-      <code>$this-&gt;mockedHttpClient</code>
+    <InvalidArgument occurrences="1">
       <code>Exception\ExceptionInterface::class</code>
     </InvalidArgument>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;createMock('Laminas\\Http\\Client')</code>
-    </InvalidPropertyAssignmentValue>
-    <MissingParamType occurrences="6">
-      <code>$data</code>
-      <code>$message</code>
-      <code>$nativeVars</code>
-      <code>$nativeVars</code>
-      <code>$nativeVars</code>
-      <code>$status</code>
-    </MissingParamType>
-    <MixedArgument occurrences="1">
-      <code>$data</code>
-    </MixedArgument>
   </file>
   <file src="test/ErrorTest.php">
     <InvalidArgument occurrences="2">
@@ -465,42 +405,24 @@
       <code>$message</code>
       <code>'-32700'</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="2">
-      <code>$code</code>
-      <code>$error</code>
-    </MissingParamType>
-    <MixedArgument occurrences="1">
-      <code>$code</code>
+    <MixedArgument occurrences="2">
+      <code>Json\Json::decode($json, Json\Json::TYPE_ARRAY)</code>
+      <code>Json\Json::decode($json, Json\Json::TYPE_ARRAY)</code>
     </MixedArgument>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
+    <RedundantCondition occurrences="1">
+      <code>assertIsArray</code>
+    </RedundantCondition>
   </file>
   <file src="test/RequestTest.php">
     <InvalidArgument occurrences="1">
       <code>$spec[1]</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="4">
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-    </InvalidScalarArgument>
-    <MissingParamType occurrences="1">
-      <code>$json</code>
-    </MissingParamType>
-    <MixedArgument occurrences="1">
-      <code>$json</code>
-    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$test</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="4">
-      <code>var_export($json, 1)</code>
-      <code>var_export($params, 1)</code>
-      <code>var_export($params, 1)</code>
-      <code>var_export($params, 1)</code>
-    </PossiblyNullArgument>
   </file>
   <file src="test/ResponseTest.php">
     <InvalidScalarArgument occurrences="1">
@@ -527,12 +449,6 @@
       <code>$object</code>
       <code>new Json\Json()</code>
     </InvalidCast>
-    <InvalidScalarArgument occurrences="4">
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="1">
       <code>$decoded['result']</code>
     </MixedArgument>
@@ -548,14 +464,6 @@
       <code>setTarget</code>
       <code>setTarget</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="2">
-      <code>var_export($result, 1)</code>
-      <code>var_export($result, 1)</code>
-    </PossiblyNullArgument>
-    <PossiblyNullOperand occurrences="2">
-      <code>var_export($test, 1)</code>
-      <code>var_export($test, 1)</code>
-    </PossiblyNullOperand>
     <PossiblyNullReference occurrences="13">
       <code>getCallback</code>
       <code>getCode</code>
@@ -577,19 +485,12 @@
   </file>
   <file src="test/Smd/ServiceTest.php">
     <InvalidArgument occurrences="2">
-      <code>new stdClass</code>
-      <code>new stdClass</code>
+      <code>new stdClass()</code>
+      <code>new stdClass()</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="4">
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
+    <InvalidScalarArgument occurrences="1">
       <code>123</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="2">
-      <code>testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase</code>
-      <code>testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar</code>
-    </MissingReturnType>
     <MixedArgument occurrences="5">
       <code>$params</code>
       <code>$params</code>
@@ -636,19 +537,8 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
-    <PossiblyNullArgument occurrences="3">
-      <code>var_export($params, 1)</code>
-      <code>var_export($params, 1)</code>
-      <code>var_export($params, 1)</code>
-    </PossiblyNullArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>assertIsString</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/SmdTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>'Laminas\Json\Server\Smd\Service'</code>
-    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>$service</code>
     </InvalidArgument>
@@ -684,9 +574,6 @@
       <code>$smd</code>
       <code>$smd</code>
     </MixedAssignment>
-    <PossiblyInvalidMethodCall occurrences="1">
-      <code>getName</code>
-    </PossiblyInvalidMethodCall>
     <RedundantCondition occurrences="1">
       <code>assertIsArray</code>
     </RedundantCondition>
@@ -707,13 +594,5 @@
     <DeprecatedInterface occurrences="1">
       <code>JsonSerializableLaminasImpl</code>
     </DeprecatedInterface>
-  </file>
-  <file src="test/TestAsset/TestIteratorAggregate.php">
-    <MissingPropertyType occurrences="1">
-      <code>$array</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;array</code>
-    </MixedArgument>
   </file>
 </files>

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,8 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Server\Cache as ServerCache;
+
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function is_readable;
+use function is_string;
+use function is_writable;
+use function restore_error_handler;
+use function set_error_handler;
+use function unlink;
+
+use const E_WARNING;
 
 /**
  * Cache server definition and SMD.
@@ -15,12 +30,12 @@ class Cache extends ServerCache
      * Returns true on success, false on failure
      *
      * @param  string $filename
-     * @param  Server $server
      * @return bool
      */
     public static function saveSmd($filename, Server $server)
     {
-        if (! is_string($filename)
+        if (
+            ! is_string($filename)
             || (! file_exists($filename) && ! is_writable(dirname($filename)))
         ) {
             return false;
@@ -52,7 +67,8 @@ class Cache extends ServerCache
      */
     public static function getSmd($filename)
     {
-        if (! is_string($filename)
+        if (
+            ! is_string($filename)
             || ! file_exists($filename)
             || ! is_readable($filename)
         ) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Http\Client as HttpClient;
@@ -48,9 +50,9 @@ class Client implements ServerClient
      * @param string $server Full address of the JSON-RPC service.
      * @param HttpClient $httpClient HTTP Client to use for requests.
      */
-    public function __construct($server, HttpClient $httpClient = null)
+    public function __construct($server, ?HttpClient $httpClient = null)
     {
-        $this->httpClient = $httpClient ?: new HttpClient();
+        $this->httpClient    = $httpClient ?: new HttpClient();
         $this->serverAddress = $server;
     }
 
@@ -113,7 +115,7 @@ class Client implements ServerClient
         }
 
         // Set default Accept and Content-Type headers unless already set.
-        $headers = $httpRequest->getHeaders();
+        $headers      = $httpRequest->getHeaders();
         $headersToAdd = [];
         if (! $headers->has('Content-Type')) {
             $headersToAdd['Content-Type'] = 'application/json-rpc';

--- a/src/Error.php
+++ b/src/Error.php
@@ -1,17 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Json\Json;
 
+use function is_bool;
+use function is_float;
+use function is_numeric;
+use function is_scalar;
+use function is_string;
+
 class Error
 {
-    const ERROR_PARSE           = -32700;
-    const ERROR_INVALID_REQUEST = -32600;
-    const ERROR_INVALID_METHOD  = -32601;
-    const ERROR_INVALID_PARAMS  = -32602;
-    const ERROR_INTERNAL        = -32603;
-    const ERROR_OTHER           = -32000;
+    public const ERROR_PARSE           = -32700;
+    public const ERROR_INVALID_REQUEST = -32600;
+    public const ERROR_INVALID_METHOD  = -32601;
+    public const ERROR_INVALID_PARAMS  = -32602;
+    public const ERROR_INTERNAL        = -32603;
+    public const ERROR_OTHER           = -32000;
 
     /**
      * Current code

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface

--- a/src/Exception/ErrorException.php
+++ b/src/Exception/ErrorException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 /**

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 interface ExceptionInterface

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 /**

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Exception;
 
 class RuntimeException extends \RuntimeException implements ExceptionInterface

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,9 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Exception;
 use Laminas\Json\Json;
+
+use function array_key_exists;
+use function count;
+use function get_class_methods;
+use function in_array;
+use function is_string;
+use function preg_match;
+use function ucfirst;
 
 /**
  * @todo Revised method regex to allow NS; however, should SMD be revised to
@@ -76,7 +86,7 @@ class Request
                 continue;
             }
 
-            if ($key == 'jsonrpc') {
+            if ($key === 'jsonrpc') {
                 $this->setVersion($value);
                 continue;
             }
@@ -94,7 +104,7 @@ class Request
     public function addParam($value, $key = null)
     {
         if ((null === $key) || ! is_string($key)) {
-            $index = count($this->params);
+            $index                = count($this->params);
             $this->params[$index] = $value;
             return $this;
         }
@@ -121,7 +131,7 @@ class Request
      * Overwrite params.
      *
      * @param  array $params
-     * @return \Laminas\Json\Server\Request
+     * @return Request
      */
     public function setParams(array $params)
     {
@@ -231,7 +241,7 @@ class Request
      */
     public function setVersion($version)
     {
-        if ('2.0' == $version) {
+        if ('2.0' === $version) {
             $this->version = '2.0';
             return $this;
         }
@@ -274,7 +284,7 @@ class Request
     public function toJson()
     {
         $jsonArray = [
-            'method' => $this->getMethod()
+            'method' => $this->getMethod(),
         ];
 
         if (null !== ($id = $this->getId())) {
@@ -286,7 +296,7 @@ class Request
             $jsonArray['params'] = $params;
         }
 
-        if ('2.0' == $this->getVersion()) {
+        if ('2.0' === $this->getVersion()) {
             $jsonArray['jsonrpc'] = '2.0';
         }
 

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Request;
 
 use Laminas\Json\Server\Request as JsonRequest;
+
+use function file_get_contents;
 
 class Http extends JsonRequest
 {
@@ -18,7 +22,7 @@ class Http extends JsonRequest
      */
     public function __construct()
     {
-        $json = file_get_contents('php://input');
+        $json          = file_get_contents('php://input');
         $this->rawJson = $json;
         if (! empty($json)) {
             $this->loadJson($json);

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,9 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Json\Exception\RuntimeException;
 use Laminas\Json\Json;
+
+use function get_class_methods;
+use function in_array;
+use function is_array;
+use function ucfirst;
 
 class Response
 {
@@ -42,9 +49,7 @@ class Response
      */
     protected $version;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $args;
 
     /**
@@ -57,8 +62,8 @@ class Response
     {
         // re-produce error state
         if (isset($options['error']) && is_array($options['error'])) {
-            $error = $options['error'];
-            $errorData = isset($error['data']) ? $error['data'] : null;
+            $error            = $options['error'];
+            $errorData        = $error['data'] ?? null;
             $options['error'] = new Error($error['message'], $error['code'], $errorData);
         }
 
@@ -134,7 +139,7 @@ class Response
      * @param  mixed $error
      * @return self
      */
-    public function setError(Error $error = null)
+    public function setError(?Error $error = null)
     {
         $this->error = $error;
         return $this;
@@ -191,7 +196,7 @@ class Response
     public function setVersion($version)
     {
         $version = (string) $version;
-        if ('2.0' == $version) {
+        if ('2.0' === $version) {
             $this->version = '2.0';
             return $this;
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -69,7 +69,7 @@ class Response
 
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
-            $method = 'set' . ucfirst($key);
+            $method = 'set' . ucfirst((string) $key);
             if (in_array($method, $methods)) {
                 $this->$method($value);
                 continue;

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -1,8 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Response;
 
 use Laminas\Json\Server\Response as JsonResponse;
+
+use function header;
+use function headers_sent;
 
 class Http extends JsonResponse
 {

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -1,16 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server;
 
 use Laminas\Json\Json;
 use Laminas\Json\Server\Exception\InvalidArgumentException;
 use Laminas\Json\Server\Exception\RuntimeException;
 
+use function array_key_exists;
+use function in_array;
+use function is_array;
+use function method_exists;
+use function preg_match;
+use function ucfirst;
+
 class Smd
 {
-    const ENV_JSONRPC_1 = 'JSON-RPC-1.0';
-    const ENV_JSONRPC_2 = 'JSON-RPC-2.0';
-    const SMD_VERSION   = '2.0';
+    public const ENV_JSONRPC_1 = 'JSON-RPC-1.0';
+    public const ENV_JSONRPC_2 = 'JSON-RPC-2.0';
+    public const SMD_VERSION   = '2.0';
 
     /**
      * Content type.
@@ -116,7 +125,7 @@ class Smd
      *
      * @param  string $transport
      * @return self
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setTransport($transport)
     {
@@ -143,7 +152,7 @@ class Smd
      *
      * @param  string $envelopeType
      * @return self
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setEnvelope($envelopeType)
     {
@@ -170,7 +179,7 @@ class Smd
      *
      * @param  string $type
      * @return self
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setContentType($type)
     {
@@ -287,8 +296,8 @@ class Smd
      *
      * @param Smd\Service|array $service
      * @return self
-     * @throws Exception\RuntimeException
-     * @throws Exception\InvalidArgumentException
+     * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function addService($service)
     {
@@ -393,8 +402,14 @@ class Smd
         $transport   = $this->getTransport();
         $envelope    = $this->getEnvelope();
         $contentType = $this->getContentType();
-        $SMDVersion  = static::SMD_VERSION;
-        $service     = compact('transport', 'envelope', 'contentType', 'SMDVersion', 'description');
+        $smdVersion  = static::SMD_VERSION;
+        $service     = [
+            'transport'   => $transport,
+            'envelope'    => $envelope,
+            'contentType' => $contentType,
+            'SMDVersion'  => $smdVersion,
+            'description' => $description,
+        ];
 
         if (null !== ($target = $this->getTarget())) {
             $service['target'] = $target;
@@ -425,9 +440,9 @@ class Smd
      */
     public function toDojoArray()
     {
-        $SMDVersion  = '.1';
+        $smdVersion  = '.1';
         $serviceType = 'JSON-RPC';
-        $service     = compact('SMDVersion', 'serviceType');
+        $service     = ['SMDVersion' => $smdVersion, 'serviceType' => $serviceType];
         $target      = $this->getTarget();
         $services    = $this->getServices();
 

--- a/src/Smd.php
+++ b/src/Smd.php
@@ -9,8 +9,10 @@ use Laminas\Json\Server\Exception\InvalidArgumentException;
 use Laminas\Json\Server\Exception\RuntimeException;
 
 use function array_key_exists;
+use function assert;
 use function in_array;
 use function is_array;
+use function is_string;
 use function method_exists;
 use function preg_match;
 use function ucfirst;
@@ -403,7 +405,8 @@ class Smd
         $envelope    = $this->getEnvelope();
         $contentType = $this->getContentType();
         $smdVersion  = static::SMD_VERSION;
-        $service     = [
+        assert(is_string($smdVersion));
+        $service = [
             'transport'   => $transport,
             'envelope'    => $envelope,
             'contentType' => $contentType,

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -34,10 +34,9 @@ class Service
     /** @var string */
     protected $envelope = Smd::ENV_JSONRPC_1;
 
-    /** @var string */
-    protected $name;
+    protected string $name = '';
 
-    /** @var string|array */
+    /** @var null|string|array */
     protected $return;
 
     /** @var string|null */
@@ -134,7 +133,7 @@ class Service
             $this->setOptions($spec);
         }
 
-        if (null === $this->getName()) {
+        if ('' === $this->getName()) {
             throw new InvalidArgumentException('SMD service description requires a name; none provided');
         }
     }
@@ -165,13 +164,11 @@ class Service
     /**
      * Set service name.
      *
-     * @param  string $name
      * @return self
      * @throws InvalidArgumentException
      */
-    public function setName($name)
+    public function setName(string $name)
     {
-        $name = (string) $name;
         if (! preg_match($this->nameRegex, $name)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid name "%s" provided for service; must follow PHP method naming conventions',
@@ -185,10 +182,8 @@ class Service
 
     /**
      * Retrieve name.
-     *
-     * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -240,10 +235,8 @@ class Service
 
     /**
      * Get service target.
-     *
-     * @return string
      */
-    public function getTarget()
+    public function getTarget(): ?string
     {
         return $this->target;
     }
@@ -425,7 +418,7 @@ class Service
     /**
      * Get return type.
      *
-     * @return string|array
+     * @return null|string|array
      */
     public function getReturn()
     {

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -1,10 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Json\Server\Smd;
 
 use Laminas\Json\Json;
 use Laminas\Json\Server\Exception\InvalidArgumentException;
 use Laminas\Json\Server\Smd;
+
+use function array_key_exists;
+use function array_keys;
+use function array_search;
+use function get_class_methods;
+use function gettype;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function ksort;
+use function preg_match;
+use function sprintf;
+use function strtolower;
+use function ucfirst;
 
 /**
  * Create Service Mapping Description for a method
@@ -14,24 +31,25 @@ use Laminas\Json\Server\Smd;
  */
 class Service
 {
-    /**#@+
-     * Service metadata
-     *
-     * @var string
-     */
-    protected $envelope  = Smd::ENV_JSONRPC_1;
+    /** @var string */
+    protected $envelope = Smd::ENV_JSONRPC_1;
+
+    /** @var string */
     protected $name;
+
+    /** @var string|array */
     protected $return;
+
+    /** @var string|null */
     protected $target;
+
+    /** @var string */
     protected $transport = 'POST';
-    /**#@-*/
 
     /**
      * Allowed envelope types.
-     *
-     * @var array
      */
-    protected $envelopeTypes = [
+    protected array $envelopeTypes = [
         Smd::ENV_JSONRPC_1,
         Smd::ENV_JSONRPC_2,
     ];
@@ -41,6 +59,7 @@ class Service
      *
      * @link http://php.net/manual/en/language.oop5.basic.php
      * @link http://www.jsonrpc.org/specification#request_object
+     *
      * @var string
      */
     protected $nameRegex = '/^(?!^rpc\.)[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\.\\\]*$/';
@@ -105,7 +124,7 @@ class Service
 
     /**
      * @param string|array $spec
-     * @throws InvalidArgumentException if no name provided
+     * @throws InvalidArgumentException If no name provided.
      */
     public function __construct($spec)
     {
@@ -115,7 +134,7 @@ class Service
             $this->setOptions($spec);
         }
 
-        if (null == $this->getName()) {
+        if (null === $this->getName()) {
             throw new InvalidArgumentException('SMD service description requires a name; none provided');
         }
     }
@@ -130,7 +149,7 @@ class Service
     {
         $methods = get_class_methods($this);
         foreach ($options as $key => $value) {
-            if ('options' == strtolower($key)) {
+            if ('options' === strtolower($key)) {
                 continue;
             }
 
@@ -327,7 +346,7 @@ class Service
             }
 
             $type  = $options['type'];
-            $order = (array_key_exists('order', $options)) ? $options['order'] : null;
+            $order = array_key_exists('order', $options) ? $options['order'] : null;
             $this->addParam($type, $options, $order);
         }
 
@@ -428,10 +447,23 @@ class Service
         $name       = $this->getName();
 
         if (empty($target)) {
-            return compact('envelope', 'transport', 'name', 'parameters', 'returns');
+            return [
+                'envelope'   => $envelope,
+                'transport'  => $transport,
+                'name'       => $name,
+                'parameters' => $parameters,
+                'returns'    => $returns,
+            ];
         }
 
-        return compact('envelope', 'target', 'transport', 'name', 'parameters', 'returns');
+        return [
+            'envelope'   => $envelope,
+            'target'     => $target,
+            'transport'  => $transport,
+            'name'       => $name,
+            'parameters' => $parameters,
+            'returns'    => $returns,
+        ];
     }
 
     /**
@@ -478,7 +510,7 @@ class Service
         }
 
         $paramType = $this->paramMap[$type];
-        if (! $isReturn && ('null' == $paramType)) {
+        if (! $isReturn && ('null' === $paramType)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid param type provided ("%s")',
                 $type

--- a/src/Smd/Service.php
+++ b/src/Smd/Service.php
@@ -182,8 +182,10 @@ class Service
 
     /**
      * Retrieve name.
+     *
+     * @return string
      */
-    public function getName(): string
+    public function getName()
     {
         return $this->name;
     }
@@ -235,8 +237,10 @@ class Service
 
     /**
      * Get service target.
+     *
+     * @return null|string
      */
-    public function getTarget(): ?string
+    public function getTarget()
     {
         return $this->target;
     }

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -1,27 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json\Server;
 use PHPUnit\Framework\TestCase;
 
+use function file_exists;
+use function is_writable;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
 class CacheTest extends TestCase
 {
-    /**
-     * @var Server\Server
-     */
+    /** @var Server\Server */
     protected $server;
 
-    /**
-     * @var false|string
-     */
+    /** @var false|string */
     protected $cacheFile;
 
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -42,8 +44,6 @@ class CacheTest extends TestCase
     /**
      * Tears down the fixture, for example, close a network connection.
      * This method is called after a test is executed.
-     *
-     * @return void
      */
     public function tearDown(): void
     {

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -54,12 +54,12 @@ class CacheTest extends TestCase
 
     public function testRetrievingSmdCacheShouldReturnFalseIfCacheDoesNotExist(): void
     {
-        $this->assertFalse(Server\Cache::getSmd($this->cacheFile));
+        self::assertFalse(Server\Cache::getSmd($this->cacheFile));
     }
 
     public function testSavingSmdCacheShouldReturnTrueOnSuccess(): void
     {
-        $this->assertTrue(Server\Cache::saveSmd($this->cacheFile, $this->server));
+        self::assertTrue(Server\Cache::saveSmd($this->cacheFile, $this->server));
     }
 
     public function testSavedCacheShouldMatchGeneratedCache(): void
@@ -67,17 +67,17 @@ class CacheTest extends TestCase
         $this->testSavingSmdCacheShouldReturnTrueOnSuccess();
         $json = $this->server->getServiceMap()->toJSON();
         $test = Server\Cache::getSmd($this->cacheFile);
-        $this->assertSame($json, $test);
+        self::assertSame($json, $test);
     }
 
     public function testDeletingSmdShouldReturnFalseOnFailure(): void
     {
-        $this->assertFalse(Server\Cache::deleteSmd($this->cacheFile));
+        self::assertFalse(Server\Cache::deleteSmd($this->cacheFile));
     }
 
     public function testDeletingSmdShouldReturnTrueOnSuccess(): void
     {
         $this->testSavingSmdCacheShouldReturnTrueOnSuccess();
-        $this->assertTrue(Server\Cache::deleteSmd($this->cacheFile));
+        self::assertTrue(Server\Cache::deleteSmd($this->cacheFile));
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -49,30 +49,30 @@ class ClientTest extends TestCase
     {
         $jsonClient = new Client('http://foo');
         $httpClient = $jsonClient->getHttpClient();
-        $this->assertInstanceOf(HttpClient::class, $httpClient);
-        $this->assertSame($httpClient, $jsonClient->getHttpClient());
+        self::assertInstanceOf(HttpClient::class, $httpClient);
+        self::assertSame($httpClient, $jsonClient->getHttpClient());
     }
 
     public function testSettingAndGettingHttpClient(): void
     {
         $jsonClient = new Client('http://foo');
-        $this->assertNotSame($this->httpClient, $jsonClient->getHttpClient());
+        self::assertNotSame($this->httpClient, $jsonClient->getHttpClient());
 
         $jsonClient->setHttpClient($this->httpClient);
-        $this->assertSame($this->httpClient, $jsonClient->getHttpClient());
+        self::assertSame($this->httpClient, $jsonClient->getHttpClient());
     }
 
     public function testSettingHttpClientViaConstructor(): void
     {
         $jsonClient = new Client('http://foo', $this->httpClient);
         $httpClient = $jsonClient->getHttpClient();
-        $this->assertSame($this->httpClient, $httpClient);
+        self::assertSame($this->httpClient, $httpClient);
     }
 
     public function testLastRequestAndResponseAreInitiallyNull(): void
     {
-        $this->assertNull($this->jsonClient->getLastRequest());
-        $this->assertNull($this->jsonClient->getLastResponse());
+        self::assertNull($this->jsonClient->getLastRequest());
+        self::assertNull($this->jsonClient->getLastResponse());
     }
 
     public function testLastRequestAndResponseAreSetAfterRpcMethodCall(): void
@@ -80,8 +80,8 @@ class ClientTest extends TestCase
         $this->setServerResponseTo(true);
         $this->jsonClient->call('foo');
 
-        $this->assertInstanceOf(Request::class, $this->jsonClient->getLastRequest());
-        $this->assertInstanceOf(Response::class, $this->jsonClient->getLastResponse());
+        self::assertInstanceOf(Request::class, $this->jsonClient->getLastRequest());
+        self::assertInstanceOf(Response::class, $this->jsonClient->getLastResponse());
     }
 
     public function testSuccessfulRpcMethodCallWithNoParameters(): void
@@ -90,15 +90,15 @@ class ClientTest extends TestCase
         $expectedReturn = 7;
 
         $this->setServerResponseTo($expectedReturn);
-        $this->assertSame($expectedReturn, $this->jsonClient->call($expectedMethod));
+        self::assertSame($expectedReturn, $this->jsonClient->call($expectedMethod));
 
         $request  = $this->jsonClient->getLastRequest();
         $response = $this->jsonClient->getLastResponse();
 
-        $this->assertSame($expectedMethod, $request->getMethod());
-        $this->assertSame([], $request->getParams());
-        $this->assertSame($expectedReturn, $response->getResult());
-        $this->assertFalse($response->isError());
+        self::assertSame($expectedMethod, $request->getMethod());
+        self::assertSame([], $request->getParams());
+        self::assertSame($expectedReturn, $response->getResult());
+        self::assertFalse($response->isError());
     }
 
     public function testSuccessfulRpcMethodCallWithParameters(): void
@@ -110,21 +110,21 @@ class ClientTest extends TestCase
         $this->setServerResponseTo($expectedReturn);
 
         $actualReturn = $this->jsonClient->call($expectedMethod, $expectedParams);
-        $this->assertSame($expectedReturn, $actualReturn);
+        self::assertSame($expectedReturn, $actualReturn);
 
         $request  = $this->jsonClient->getLastRequest();
         $response = $this->jsonClient->getLastResponse();
 
-        $this->assertSame($expectedMethod, $request->getMethod());
+        self::assertSame($expectedMethod, $request->getMethod());
         $params = $request->getParams();
-        $this->assertSame(count($expectedParams), count($params));
-        $this->assertSame($expectedParams[0], $params[0]);
-        $this->assertSame($expectedParams[1], $params[1]);
-        $this->assertSame($expectedParams[2], $params[2]);
-        $this->assertSame($expectedParams['foo'], $params['foo']);
+        self::assertSame(count($expectedParams), count($params));
+        self::assertSame($expectedParams[0], $params[0]);
+        self::assertSame($expectedParams[1], $params[1]);
+        self::assertSame($expectedParams[2], $params[2]);
+        self::assertSame($expectedParams['foo'], $params['foo']);
 
-        $this->assertSame($expectedReturn, $response->getResult());
-        $this->assertFalse($response->isError());
+        self::assertSame($expectedReturn, $response->getResult());
+        self::assertFalse($response->isError());
     }
 
     public function testRpcMethodCallThrowsOnHttpFailure(): void
@@ -170,7 +170,7 @@ class ClientTest extends TestCase
         $this->jsonClient->call('foo');
         $uri = $this->jsonClient->getHttpClient()->getUri()->toString();
 
-        $this->assertEquals($changedUri, $uri);
+        self::assertEquals($changedUri, $uri);
     }
 
     public function testSettingNoHttpClientUriForcesClientToSetUri(): void
@@ -183,22 +183,22 @@ class ClientTest extends TestCase
         $this->jsonClient->setHttpClient($this->httpClient);
 
         $this->setServerResponseTo(null);
-        $this->assertNull($this->jsonClient->getHttpClient()->getRequest()->getUriString());
+        self::assertNull($this->jsonClient->getHttpClient()->getRequest()->getUriString());
         $this->jsonClient->call('foo');
         $uri = $this->jsonClient->getHttpClient()->getUri();
 
-        $this->assertEquals($baseUri, $uri->toString());
+        self::assertEquals($baseUri, $uri->toString());
     }
 
     public function testCustomHttpClientUserAgentIsNotOverridden(): void
     {
-        $this->assertFalse(
+        self::assertFalse(
             $this->httpClient->getHeader('User-Agent'),
             'UA is null if no request was made'
         );
         $this->setServerResponseTo(null);
-        $this->assertNull($this->jsonClient->call('method'));
-        $this->assertSame(
+        self::assertNull($this->jsonClient->call('method'));
+        self::assertSame(
             'Laminas_Json_Server_Client',
             $this->httpClient->getHeader('User-Agent'),
             'If no custom UA is set, set Laminas_Json_Server_Client'
@@ -208,8 +208,8 @@ class ClientTest extends TestCase
         $this->httpClient->setHeaders(['User-Agent' => $expectedUserAgent]);
 
         $this->setServerResponseTo(null);
-        $this->assertNull($this->jsonClient->call('method'));
-        $this->assertSame($expectedUserAgent, $this->httpClient->getHeader('User-Agent'));
+        self::assertNull($this->jsonClient->call('method'));
+        self::assertSame($expectedUserAgent, $this->httpClient->getHeader('User-Agent'));
     }
 
     /**
@@ -244,8 +244,8 @@ class ClientTest extends TestCase
         $jsonClient = new Client('http://foo');
         $jsonClient->getHttpClient()->setAdapter($testAdapter);
         $jsonClient->doRequest($request);
-        $this->assertSame('application/json-rpc', $jsonClient->getHttpClient()->getHeader('Content-Type'));
-        $this->assertSame('application/json-rpc', $jsonClient->getHttpClient()->getHeader('Accept'));
+        self::assertSame('application/json-rpc', $jsonClient->getHttpClient()->getHeader('Content-Type'));
+        self::assertSame('application/json-rpc', $jsonClient->getHttpClient()->getHeader('Accept'));
     }
 
     public function testClientShouldNotOverwriteAcceptAndContentTypeHeadersIfAlreadyPresentInRequest(): void
@@ -265,8 +265,8 @@ class ClientTest extends TestCase
         $jsonClient = new Client('http://foo', $httpClient);
         $jsonClient->getHttpClient()->setAdapter($testAdapter);
         $jsonClient->doRequest($request);
-        $this->assertSame('application/jsonrequest', $jsonClient->getHttpClient()->getHeader('Content-Type'));
-        $this->assertSame('application/jsonrequest', $jsonClient->getHttpClient()->getHeader('Accept'));
+        self::assertSame('application/jsonrequest', $jsonClient->getHttpClient()->getHeader('Content-Type'));
+        self::assertSame('application/jsonrequest', $jsonClient->getHttpClient()->getHeader('Accept'));
     }
 
     /**

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -27,20 +27,20 @@ class ErrorTest extends TestCase
 
     public function testCodeShouldBeErrOtherByDefault(): void
     {
-        $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
+        self::assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
     }
 
     public function testSetCodeShouldCastToInteger(): void
     {
         $this->error->setCode('-32700');
-        $this->assertEquals(-32700, $this->error->getCode());
+        self::assertEquals(-32700, $this->error->getCode());
     }
 
     public function testCodeShouldBeLimitedToStandardIntegers(): void
     {
         foreach ([null, true, 'foo', [], new stdClass(), 2.0] as $code) {
             $this->error->setCode($code);
-            $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
+            self::assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
         }
     }
 
@@ -48,7 +48,7 @@ class ErrorTest extends TestCase
     {
         foreach (range(-32099, -32000) as $code) {
             $this->error->setCode($code);
-            $this->assertEquals($code, $this->error->getCode());
+            self::assertEquals($code, $this->error->getCode());
         }
     }
 
@@ -67,19 +67,19 @@ class ErrorTest extends TestCase
     public function testCodeShouldAllowArbitraryErrorCode(int $code): void
     {
         $this->error->setCode($code);
-        $this->assertEquals($code, $this->error->getCode());
+        self::assertEquals($code, $this->error->getCode());
     }
 
     public function testMessageShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->error->getMessage());
+        self::assertNull($this->error->getMessage());
     }
 
     public function testSetMessageShouldCastToString(): void
     {
         foreach ([true, 2.0, 25] as $message) {
             $this->error->setMessage($message);
-            $this->assertEquals((string) $message, $this->error->getMessage());
+            self::assertEquals((string) $message, $this->error->getMessage());
         }
     }
 
@@ -87,20 +87,20 @@ class ErrorTest extends TestCase
     {
         foreach ([[], new stdClass()] as $message) {
             $this->error->setMessage($message);
-            $this->assertNull($this->error->getMessage());
+            self::assertNull($this->error->getMessage());
         }
     }
 
     public function testDataShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->error->getData());
+        self::assertNull($this->error->getData());
     }
 
     public function testShouldAllowArbitraryData(): void
     {
         foreach ([true, 'foo', 2, 2.0, [], new stdClass()] as $datum) {
             $this->error->setData($datum);
-            $this->assertEquals($datum, $this->error->getData());
+            self::assertEquals($datum, $this->error->getData());
         }
     }
 
@@ -134,17 +134,17 @@ class ErrorTest extends TestCase
 
     public function validateArray(array $error): void
     {
-        $this->assertIsArray($error);
-        $this->assertArrayHasKey('code', $error);
-        $this->assertArrayHasKey('message', $error);
-        $this->assertArrayHasKey('data', $error);
+        self::assertIsArray($error);
+        self::assertArrayHasKey('code', $error);
+        self::assertArrayHasKey('message', $error);
+        self::assertArrayHasKey('data', $error);
 
-        $this->assertIsInt($error['code']);
-        $this->assertIsString($error['message']);
-        $this->assertIsArray($error['data']);
+        self::assertIsInt($error['code']);
+        self::assertIsString($error['message']);
+        self::assertIsArray($error['data']);
 
-        $this->assertEquals($this->error->getCode(), $error['code']);
-        $this->assertEquals($this->error->getMessage(), $error['message']);
-        $this->assertSame($this->error->getData(), $error['data']);
+        self::assertEquals($this->error->getCode(), $error['code']);
+        self::assertEquals($this->error->getMessage(), $error['message']);
+        self::assertSame($this->error->getData(), $error['data']);
     }
 }

--- a/test/ErrorTest.php
+++ b/test/ErrorTest.php
@@ -1,23 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json;
 use Laminas\Json\Server;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function range;
 
 class ErrorTest extends TestCase
 {
-    /**
-     * @var Server\Error
-     */
+    /** @var Server\Error */
     protected $error;
 
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -37,7 +38,7 @@ class ErrorTest extends TestCase
 
     public function testCodeShouldBeLimitedToStandardIntegers(): void
     {
-        foreach ([null, true, 'foo', [], new \stdClass, 2.0] as $code) {
+        foreach ([null, true, 'foo', [], new stdClass(), 2.0] as $code) {
             $this->error->setCode($code);
             $this->assertEquals(Server\Error::ERROR_OTHER, $this->error->getCode());
         }
@@ -63,7 +64,7 @@ class ErrorTest extends TestCase
     /**
      * @dataProvider arbitraryErrorCodes
      */
-    public function testCodeShouldAllowArbitraryErrorCode($code): void
+    public function testCodeShouldAllowArbitraryErrorCode(int $code): void
     {
         $this->error->setCode($code);
         $this->assertEquals($code, $this->error->getCode());
@@ -84,7 +85,7 @@ class ErrorTest extends TestCase
 
     public function testSetMessageToNonScalarShouldSilentlyFail(): void
     {
-        foreach ([[], new \stdClass] as $message) {
+        foreach ([[], new stdClass()] as $message) {
             $this->error->setMessage($message);
             $this->assertNull($this->error->getMessage());
         }
@@ -97,7 +98,7 @@ class ErrorTest extends TestCase
 
     public function testShouldAllowArbitraryData(): void
     {
-        foreach ([true, 'foo', 2, 2.0, [], new \stdClass] as $datum) {
+        foreach ([true, 'foo', 2, 2.0, [], new stdClass()] as $datum) {
             $this->error->setData($datum);
             $this->assertEquals($datum, $this->error->getData());
         }
@@ -131,7 +132,7 @@ class ErrorTest extends TestCase
                     ->setData(['foo' => 'bar']);
     }
 
-    public function validateArray($error): void
+    public function validateArray(array $error): void
     {
         $this->assertIsArray($error);
         $this->assertArrayHasKey('code', $error);

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -1,23 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json\Json;
 use Laminas\Json\Server\Request;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function array_shift;
+use function array_values;
+use function var_export;
 
 class RequestTest extends TestCase
 {
-    /**
-     * @var Request
-     */
+    /** @var Request */
     protected $request;
 
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,7 +54,7 @@ class RequestTest extends TestCase
     public function testInvalidKeysShouldBeIgnored(): void
     {
         $count = 0;
-        foreach ([['foo', true], ['foo', new \stdClass], ['foo', []]] as $spec) {
+        foreach ([['foo', true], ['foo', new stdClass()], ['foo', []]] as $spec) {
             $this->request->addParam($spec[0], $spec[1]);
             $this->assertNull($this->request->getParam('foo'));
             $params = $this->request->getParams();
@@ -183,9 +186,9 @@ class RequestTest extends TestCase
 
     public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
     {
-        $options = $this->getOptions();
+        $options            = $this->getOptions();
         $options['jsonrpc'] = '2.0';
-        $json    = Json::encode($options);
+        $json               = Json::encode($options);
         $this->request->loadJSON($json);
         $this->assertEquals('2.0', $this->request->getVersion());
     }
@@ -194,7 +197,7 @@ class RequestTest extends TestCase
     {
         $options = $this->getOptions();
         $this->request->setOptions($options);
-        $json    = $this->request->toJSON();
+        $json = $this->request->toJSON();
         $this->validateJSON($json, $options);
     }
 
@@ -202,7 +205,7 @@ class RequestTest extends TestCase
     {
         $options = $this->getOptions();
         $this->request->setOptions($options);
-        $json    = $this->request->__toString();
+        $json = $this->request->__toString();
         $this->validateJSON($json, $options);
     }
 
@@ -231,11 +234,11 @@ class RequestTest extends TestCase
                 'four',
                 true,
             ],
-            'id'     => 'foobar'
+            'id'     => 'foobar',
         ];
     }
 
-    public function validateJSON($json, array $options): void
+    public function validateJSON(string $json, array $options): void
     {
         $test = Json::decode($json, Json::TYPE_ARRAY);
         $this->assertIsArray($test, var_export($json, 1));

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -30,25 +30,25 @@ class RequestTest extends TestCase
     public function testShouldHaveNoParamsByDefault(): void
     {
         $params = $this->request->getParams();
-        $this->assertEmpty($params);
+        self::assertEmpty($params);
     }
 
     public function testShouldBeAbleToAddAParamAsValueOnly(): void
     {
         $this->request->addParam('foo');
         $params = $this->request->getParams();
-        $this->assertCount(1, $params);
+        self::assertCount(1, $params);
         $test = array_shift($params);
-        $this->assertEquals('foo', $test);
+        self::assertEquals('foo', $test);
     }
 
     public function testShouldBeAbleToAddAParamAsKeyValuePair(): void
     {
         $this->request->addParam('bar', 'foo');
         $params = $this->request->getParams();
-        $this->assertCount(1, $params);
-        $this->assertArrayHasKey('foo', $params);
-        $this->assertEquals('bar', $params['foo']);
+        self::assertCount(1, $params);
+        self::assertArrayHasKey('foo', $params);
+        self::assertEquals('bar', $params['foo']);
     }
 
     public function testInvalidKeysShouldBeIgnored(): void
@@ -56,10 +56,10 @@ class RequestTest extends TestCase
         $count = 0;
         foreach ([['foo', true], ['foo', new stdClass()], ['foo', []]] as $spec) {
             $this->request->addParam($spec[0], $spec[1]);
-            $this->assertNull($this->request->getParam('foo'));
+            self::assertNull($this->request->getParam('foo'));
             $params = $this->request->getParams();
             ++$count;
-            $this->assertCount($count, $params);
+            self::assertCount($count, $params);
         }
     }
 
@@ -72,7 +72,7 @@ class RequestTest extends TestCase
         ];
         $this->request->addParams($params);
         $test = $this->request->getParams();
-        $this->assertSame($params, $test);
+        self::assertSame($params, $test);
     }
 
     public function testShouldBeAbleToAddMultipleNamedParamsAtOnce(): void
@@ -84,7 +84,7 @@ class RequestTest extends TestCase
         ];
         $this->request->addParams($params);
         $test = $this->request->getParams();
-        $this->assertSame($params, $test);
+        self::assertSame($params, $test);
     }
 
     public function testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce(): void
@@ -96,10 +96,10 @@ class RequestTest extends TestCase
         ];
         $this->request->addParams($params);
         $test = $this->request->getParams();
-        $this->assertEquals(array_values($params), array_values($test));
-        $this->assertArrayHasKey('foo', $test);
-        $this->assertArrayHasKey('baz', $test);
-        $this->assertContains('baz', $test);
+        self::assertEquals(array_values($params), array_values($test));
+        self::assertArrayHasKey('foo', $test);
+        self::assertArrayHasKey('baz', $test);
+        self::assertContains('baz', $test);
     }
 
     public function testSetParamsShouldOverwriteParams(): void
@@ -111,66 +111,66 @@ class RequestTest extends TestCase
             'three',
         ];
         $this->request->setParams($params);
-        $this->assertSame($params, $this->request->getParams());
+        self::assertSame($params, $this->request->getParams());
     }
 
     public function testShouldBeAbleToRetrieveParamByKeyOrIndex(): void
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = $this->request->getParams();
-        $this->assertEquals('bar', $this->request->getParam('foo'), var_export($params, true));
-        $this->assertEquals('baz', $this->request->getParam(1), var_export($params, true));
-        $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, true));
+        self::assertEquals('bar', $this->request->getParam('foo'), var_export($params, true));
+        self::assertEquals('baz', $this->request->getParam(1), var_export($params, true));
+        self::assertEquals('bat', $this->request->getParam('baz'), var_export($params, true));
     }
 
     public function testMethodShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->request->getMethod());
+        self::assertNull($this->request->getMethod());
     }
 
     public function testMethodErrorShouldBeFalseByDefault(): void
     {
-        $this->assertFalse($this->request->isMethodError());
+        self::assertFalse($this->request->isMethodError());
     }
 
     public function testMethodAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->request->setMethod('foo');
-        $this->assertEquals('foo', $this->request->getMethod());
+        self::assertEquals('foo', $this->request->getMethod());
     }
 
     public function testSettingMethodWithInvalidNameShouldSetError(): void
     {
         foreach (['1ad', 'abc-123', 'ad$$832r#@'] as $method) {
             $this->request->setMethod($method);
-            $this->assertNull($this->request->getMethod());
-            $this->assertTrue($this->request->isMethodError());
+            self::assertNull($this->request->getMethod());
+            self::assertTrue($this->request->isMethodError());
         }
     }
 
     public function testIdShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->request->getId());
+        self::assertNull($this->request->getId());
     }
 
     public function testIdAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->request->setId('foo');
-        $this->assertEquals('foo', $this->request->getId());
+        self::assertEquals('foo', $this->request->getId());
     }
 
     public function testVersionShouldBeJSONRpcV1ByDefault(): void
     {
-        $this->assertEquals('1.0', $this->request->getVersion());
+        self::assertEquals('1.0', $this->request->getVersion());
     }
 
     public function testVersionShouldBeLimitedToV1AndV2(): void
     {
         $this->testVersionShouldBeJSONRpcV1ByDefault();
         $this->request->setVersion('2.0');
-        $this->assertEquals('2.0', $this->request->getVersion());
+        self::assertEquals('2.0', $this->request->getVersion());
         $this->request->setVersion('foo');
-        $this->assertEquals('1.0', $this->request->getVersion());
+        self::assertEquals('1.0', $this->request->getVersion());
     }
 
     public function testShouldBeAbleToLoadRequestFromJSONString(): void
@@ -179,9 +179,9 @@ class RequestTest extends TestCase
         $json    = Json::encode($options);
         $this->request->loadJSON($json);
 
-        $this->assertEquals('foo', $this->request->getMethod());
-        $this->assertEquals('foobar', $this->request->getId());
-        $this->assertEquals($options['params'], $this->request->getParams());
+        self::assertEquals('foo', $this->request->getMethod());
+        self::assertEquals('foobar', $this->request->getId());
+        self::assertEquals($options['params'], $this->request->getParams());
     }
 
     public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
@@ -190,7 +190,7 @@ class RequestTest extends TestCase
         $options['jsonrpc'] = '2.0';
         $json               = Json::encode($options);
         $this->request->loadJSON($json);
-        $this->assertEquals('2.0', $this->request->getVersion());
+        self::assertEquals('2.0', $this->request->getVersion());
     }
 
     public function testShouldBeAbleToCastToJSON(): void
@@ -215,14 +215,14 @@ class RequestTest extends TestCase
     public function testMethodNamesShouldAllowDotNamespacing(): void
     {
         $this->request->setMethod('foo.bar');
-        $this->assertEquals('foo.bar', $this->request->getMethod());
+        self::assertEquals('foo.bar', $this->request->getMethod());
     }
 
     public function testIsParseErrorSetOnMalformedJson(): void
     {
         $testJson = '{"id":1, "method": "test", "params:"[1,2,3]}';
         $this->request->loadJson($testJson);
-        $this->assertTrue($this->request->isParseError());
+        self::assertTrue($this->request->isParseError());
     }
 
     public function getOptions(): array
@@ -241,18 +241,18 @@ class RequestTest extends TestCase
     public function validateJSON(string $json, array $options): void
     {
         $test = Json::decode($json, Json::TYPE_ARRAY);
-        $this->assertIsArray($test, var_export($json, true));
+        self::assertIsArray($test, var_export($json, true));
 
-        $this->assertArrayHasKey('id', $test);
-        $this->assertArrayHasKey('method', $test);
-        $this->assertArrayHasKey('params', $test);
+        self::assertArrayHasKey('id', $test);
+        self::assertArrayHasKey('method', $test);
+        self::assertArrayHasKey('params', $test);
 
-        $this->assertIsString($test['id']);
-        $this->assertIsString($test['method']);
-        $this->assertIsArray($test['params']);
+        self::assertIsString($test['id']);
+        self::assertIsString($test['method']);
+        self::assertIsArray($test['params']);
 
-        $this->assertEquals($options['id'], $test['id']);
-        $this->assertEquals($options['method'], $test['method']);
-        $this->assertSame($options['params'], $test['params']);
+        self::assertEquals($options['id'], $test['id']);
+        self::assertEquals($options['method'], $test['method']);
+        self::assertSame($options['params'], $test['params']);
     }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -118,9 +118,9 @@ class RequestTest extends TestCase
     {
         $this->testShouldBeAbleToAddMixedIndexedAndNamedParamsAtOnce();
         $params = $this->request->getParams();
-        $this->assertEquals('bar', $this->request->getParam('foo'), var_export($params, 1));
-        $this->assertEquals('baz', $this->request->getParam(1), var_export($params, 1));
-        $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, 1));
+        $this->assertEquals('bar', $this->request->getParam('foo'), var_export($params, true));
+        $this->assertEquals('baz', $this->request->getParam(1), var_export($params, true));
+        $this->assertEquals('bat', $this->request->getParam('baz'), var_export($params, true));
     }
 
     public function testMethodShouldBeNullByDefault(): void
@@ -241,7 +241,7 @@ class RequestTest extends TestCase
     public function validateJSON(string $json, array $options): void
     {
         $test = Json::decode($json, Json::TYPE_ARRAY);
-        $this->assertIsArray($test, var_export($json, 1));
+        $this->assertIsArray($test, var_export($json, true));
 
         $this->assertArrayHasKey('id', $test);
         $this->assertArrayHasKey('method', $test);

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json\Json;
@@ -10,15 +12,11 @@ use PHPUnit\Framework\TestCase;
 
 class ResponseTest extends TestCase
 {
-    /**
-     * @var Response
-     */
+    /** @var Response */
     private $response;
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -102,9 +100,9 @@ class ResponseTest extends TestCase
 
     public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
     {
-        $options = $this->getOptions();
+        $options            = $this->getOptions();
         $options['jsonrpc'] = '2.0';
-        $json    = Json::encode($options);
+        $json               = Json::encode($options);
         $this->response->loadJSON($json);
         $this->assertEquals('2.0', $this->response->getVersion());
     }
@@ -169,9 +167,7 @@ class ResponseTest extends TestCase
 
     /**
      * @param string $json
-     *
      * @group 5956
-     *
      * @dataProvider provideScalarJSONResponses
      */
     public function testLoadingScalarJSONResponseShouldThrowException($json): void
@@ -196,7 +192,7 @@ class ResponseTest extends TestCase
                 'four',
                 true,
             ],
-            'id'  => 'foobar',
+            'id'     => 'foobar',
         ];
     }
 
@@ -213,13 +209,14 @@ class ResponseTest extends TestCase
 
     /**
      * Assert that error data can be omitted
+     *
      * @see https://www.jsonrpc.org/specification#response_object
      */
     public function testSetOptionsAcceptsErrorWithEmptyDate(): void
     {
         $this->response->setOptions([
             'error' => [
-                'code' => 0,
+                'code'    => 0,
                 'message' => 'Lorem Ipsum',
             ],
         ]);

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -25,66 +25,66 @@ class ResponseTest extends TestCase
 
     public function testResultShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->response->getResult());
+        self::assertNull($this->response->getResult());
     }
 
     public function testResultAccessorsShouldWorkWithNormalInput(): void
     {
         foreach ([true, 'foo', 2, 2.0, [], ['foo' => 'bar']] as $result) {
             $this->response->setResult($result);
-            $this->assertEquals($result, $this->response->getResult());
+            self::assertEquals($result, $this->response->getResult());
         }
     }
 
     public function testResultShouldNotBeErrorByDefault(): void
     {
-        $this->assertFalse($this->response->isError());
+        self::assertFalse($this->response->isError());
     }
 
     public function testSettingErrorShouldMarkRequestAsError(): void
     {
         $error = new Error();
         $this->response->setError($error);
-        $this->assertTrue($this->response->isError());
+        self::assertTrue($this->response->isError());
     }
 
     public function testShouldBeAbleToRetrieveErrorObject(): void
     {
         $error = new Error();
         $this->response->setError($error);
-        $this->assertSame($error, $this->response->getError());
+        self::assertSame($error, $this->response->getError());
     }
 
     public function testErrorAccesorsShouldWorkWithNullInput(): void
     {
         $this->response->setError(null);
-        $this->assertNull($this->response->getError());
-        $this->assertFalse($this->response->isError());
+        self::assertNull($this->response->getError());
+        self::assertFalse($this->response->isError());
     }
 
     public function testIdShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->response->getId());
+        self::assertNull($this->response->getId());
     }
 
     public function testIdAccessorsShouldWorkWithNormalInput(): void
     {
         $this->response->setId('foo');
-        $this->assertEquals('foo', $this->response->getId());
+        self::assertEquals('foo', $this->response->getId());
     }
 
     public function testVersionShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->response->getVersion());
+        self::assertNull($this->response->getVersion());
     }
 
     public function testVersionShouldBeLimitedToV2(): void
     {
         $this->response->setVersion('2.0');
-        $this->assertEquals('2.0', $this->response->getVersion());
+        self::assertEquals('2.0', $this->response->getVersion());
         foreach (['a', 1, '1.0', true] as $version) {
             $this->response->setVersion($version);
-            $this->assertNull($this->response->getVersion());
+            self::assertNull($this->response->getVersion());
         }
     }
 
@@ -94,8 +94,8 @@ class ResponseTest extends TestCase
         $json    = Json::encode($options);
         $this->response->loadJSON($json);
 
-        $this->assertEquals('foobar', $this->response->getId());
-        $this->assertEquals($options['result'], $this->response->getResult());
+        self::assertEquals('foobar', $this->response->getId());
+        self::assertEquals($options['result'], $this->response->getResult());
     }
 
     public function testLoadingFromJSONShouldSetJSONRpcVersionWhenPresent(): void
@@ -104,7 +104,7 @@ class ResponseTest extends TestCase
         $options['jsonrpc'] = '2.0';
         $json               = Json::encode($options);
         $this->response->loadJSON($json);
-        $this->assertEquals('2.0', $this->response->getVersion());
+        self::assertEquals('2.0', $this->response->getVersion());
     }
 
     public function testResponseShouldBeAbleToCastToJSON(): void
@@ -115,15 +115,15 @@ class ResponseTest extends TestCase
         $json = $this->response->toJSON();
         $test = Json::decode($json, Json::TYPE_ARRAY);
 
-        $this->assertIsArray($test);
-        $this->assertArrayHasKey('result', $test);
-        $this->assertArrayNotHasKey('error', $test, "'error' may not coexist with 'result'");
-        $this->assertArrayHasKey('id', $test);
-        $this->assertArrayHasKey('jsonrpc', $test);
+        self::assertIsArray($test);
+        self::assertArrayHasKey('result', $test);
+        self::assertArrayNotHasKey('error', $test, "'error' may not coexist with 'result'");
+        self::assertArrayHasKey('id', $test);
+        self::assertArrayHasKey('jsonrpc', $test);
 
-        $this->assertTrue($test['result']);
-        $this->assertEquals($this->response->getId(), $test['id']);
-        $this->assertEquals($this->response->getVersion(), $test['jsonrpc']);
+        self::assertTrue($test['result']);
+        self::assertEquals($this->response->getId(), $test['id']);
+        self::assertEquals($this->response->getVersion(), $test['jsonrpc']);
     }
 
     public function testResponseShouldCastErrorToJSONIfIsError(): void
@@ -137,15 +137,15 @@ class ResponseTest extends TestCase
         $json = $this->response->toJSON();
         $test = Json::decode($json, Json::TYPE_ARRAY);
 
-        $this->assertIsArray($test);
-        $this->assertArrayNotHasKey('result', $test, "'result' may not coexist with 'error'");
-        $this->assertArrayHasKey('error', $test);
-        $this->assertArrayHasKey('id', $test);
-        $this->assertArrayNotHasKey('jsonrpc', $test);
+        self::assertIsArray($test);
+        self::assertArrayNotHasKey('result', $test, "'result' may not coexist with 'error'");
+        self::assertArrayHasKey('error', $test);
+        self::assertArrayHasKey('id', $test);
+        self::assertArrayNotHasKey('jsonrpc', $test);
 
-        $this->assertEquals($this->response->getId(), $test['id']);
-        $this->assertEquals($error->getCode(), $test['error']['code']);
-        $this->assertEquals($error->getMessage(), $test['error']['message']);
+        self::assertEquals($this->response->getId(), $test['id']);
+        self::assertEquals($error->getCode(), $test['error']['code']);
+        self::assertEquals($error->getMessage(), $test['error']['message']);
     }
 
     public function testCastToStringShouldCastToJSON(): void
@@ -155,14 +155,14 @@ class ResponseTest extends TestCase
         $json = $this->response->__toString();
         $test = Json::decode($json, Json::TYPE_ARRAY);
 
-        $this->assertIsArray($test);
-        $this->assertArrayHasKey('result', $test);
-        $this->assertArrayNotHasKey('error', $test, "'error' may not coexist with 'result'");
-        $this->assertArrayHasKey('id', $test);
-        $this->assertArrayNotHasKey('jsonrpc', $test);
+        self::assertIsArray($test);
+        self::assertArrayHasKey('result', $test);
+        self::assertArrayNotHasKey('error', $test, "'error' may not coexist with 'result'");
+        self::assertArrayHasKey('id', $test);
+        self::assertArrayNotHasKey('jsonrpc', $test);
 
-        $this->assertTrue($test['result']);
-        $this->assertEquals($this->response->getId(), $test['id']);
+        self::assertTrue($test['result']);
+        self::assertEquals($this->response->getId(), $test['id']);
     }
 
     /**
@@ -204,7 +204,7 @@ class ResponseTest extends TestCase
         $this->response->setOptions([
             0 => '2.0',
         ]);
-        $this->assertNull($this->response->getVersion());
+        self::assertNull($this->response->getVersion());
     }
 
     /**
@@ -220,9 +220,9 @@ class ResponseTest extends TestCase
                 'message' => 'Lorem Ipsum',
             ],
         ]);
-        $this->assertInstanceOf(Error::class, $this->response->getError());
-        $this->assertEquals(-32000, $this->response->getError()->getCode());
-        $this->assertEquals('Lorem Ipsum', $this->response->getError()->getMessage());
-        $this->assertEquals(null, $this->response->getError()->getData());
+        self::assertInstanceOf(Error::class, $this->response->getError());
+        self::assertEquals(-32000, $this->response->getError()->getCode());
+        self::assertEquals('Lorem Ipsum', $this->response->getError()->getMessage());
+        self::assertEquals(null, $this->response->getError()->getData());
     }
 }

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json;
@@ -10,18 +12,20 @@ use Laminas\Json\Server\Response;
 use Laminas\Server\Reflection\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+use function get_class_methods;
+use function ob_get_clean;
+use function ob_start;
+use function var_export;
+
 class ServerTest extends TestCase
 {
-    /**
-     * @var Server\Server
-     */
+    /** @var Server\Server */
     protected $server;
 
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -56,10 +60,10 @@ class ServerTest extends TestCase
     public function testBindingClassToServerShouldRegisterAllPublicMethods(): void
     {
         $this->server->setClass(Server\Server::class);
-        $test = $this->server->getFunctions();
+        $test    = $this->server->getFunctions();
         $methods = get_class_methods(Server\Server::class);
         foreach ($methods as $method) {
-            if ('_' == $method[0]) {
+            if ('_' === $method[0]) {
                 continue;
             }
             $this->assertTrue(
@@ -81,10 +85,10 @@ class ServerTest extends TestCase
     {
         $object = new Server\Server();
         $this->server->setClass($object);
-        $test = $this->server->getFunctions();
+        $test    = $this->server->getFunctions();
         $methods = get_class_methods($object);
         foreach ($methods as $method) {
-            if ('_' == $method[0]) {
+            if ('_' === $method[0]) {
                 continue;
             }
             $this->assertTrue(
@@ -98,7 +102,7 @@ class ServerTest extends TestCase
     {
         $this->server->setClass(Server\Server::class)
                      ->setClass(new Json\Json());
-        $methods = $this->server->getFunctions();
+        $methods    = $this->server->getFunctions();
         $zjsMethods = get_class_methods(Server\Server::class);
         $zjMethods  = get_class_methods(Json\Json::class);
         $this->assertGreaterThan(count($zjsMethods), count($methods));
@@ -111,8 +115,8 @@ class ServerTest extends TestCase
                      ->setClass(Response::class);
         $methods = $this->server->getFunctions();
         $this->assertTrue($methods->hasMethod('toJson'));
-        $toJSON = $methods->getMethod('toJson');
-        $this->assertEquals(Response::class, $toJSON->getCallback()->getClass());
+        $toJson = $methods->getMethod('toJson');
+        $this->assertEquals(Response::class, $toJson->getCallback()->getClass());
     }
 
     public function testGetRequestShouldInstantiateRequestObjectByDefault(): void
@@ -217,7 +221,7 @@ class ServerTest extends TestCase
         $this->assertArrayHasKey('strtolower', $services);
         $methods = get_class_methods(Server\Server::class);
         foreach ($methods as $method) {
-            if ('_' == $method[0]) {
+            if ('_' === $method[0]) {
                 continue;
             }
             $this->assertArrayHasKey($method, $services);
@@ -236,7 +240,6 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $this->assertInstanceOf(Response::class, $response);
         $this->assertFalse($response->isError());
-
 
         $request->setMethod(__NAMESPACE__ . '\\TestAsset\\FooFunc')
                 ->setId('foo');
@@ -322,11 +325,11 @@ class ServerTest extends TestCase
                 ->setParams([
                     'three' => 3,
                     'two'   => 2,
-                    'one'   => 1
+                    'one'   => 1,
                 ])
                 ->setId('foo');
         $response = $this->server->handle();
-        $result = $response->getResult();
+        $result   = $response->getResult();
 
         $this->assertIsArray($result);
         $this->assertEquals(1, $result[0]);
@@ -347,7 +350,7 @@ class ServerTest extends TestCase
                 ])
                 ->setId('foo');
         $response = $this->server->handle();
-        $result = $response->getResult();
+        $result   = $response->getResult();
 
         $this->assertIsArray($result);
         $this->assertEquals(1, $result[0]);
@@ -364,7 +367,7 @@ class ServerTest extends TestCase
                 ->setParams([
                     'three' => 3,
                     'two'   => 2,
-                 ])
+                ])
                 ->setId('foo');
         $response = $this->server->handle();
 
@@ -448,7 +451,7 @@ class ServerTest extends TestCase
     {
         $this->server->setClass(TestAsset\Foo::class);
         $functions = $this->server->getFunctions();
-        $server = new Server\Server();
+        $server    = new Server\Server();
         $server->loadFunctions($functions);
         $this->assertEquals($functions->toArray(), $server->getFunctions()->toArray());
     }
@@ -492,12 +495,12 @@ class ServerTest extends TestCase
         $request = $this->server->getRequest();
         $request->setMethod('bar')
                 ->setParams([
-                    'two'   => 2,
-                    'one'   => 1,
+                    'two' => 2,
+                    'one' => 1,
                 ])
                 ->setId('foo');
         $response = $this->server->handle();
-        $result = $response->getResult();
+        $result   = $response->getResult();
 
         $this->assertIsArray($result);
         $this->assertEquals(1, $result[0]);
@@ -520,7 +523,7 @@ class ServerTest extends TestCase
                 ])
                 ->setId('foo');
         $response = $this->server->handle();
-        $result = $response->getResult();
+        $result   = $response->getResult();
 
         $this->assertIsArray($result);
         $this->assertEquals(1, $result[0]);

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -36,7 +36,7 @@ class ServerTest extends TestCase
     {
         $this->server->addFunction('strtolower');
         $methods = $this->server->getFunctions();
-        $this->assertTrue($methods->hasMethod('strtolower'));
+        self::assertTrue($methods->hasMethod('strtolower'));
     }
 
     public function testShouldBeAbleToBindCallbackToServer(): void
@@ -47,14 +47,14 @@ class ServerTest extends TestCase
             $this->markTestIncomplete('PHPUnit docblocks may be incorrect');
         }
         $methods = $this->server->getFunctions();
-        $this->assertTrue($methods->hasMethod('setUp'));
+        self::assertTrue($methods->hasMethod('setUp'));
     }
 
     public function testShouldBeAbleToBindClassToServer(): void
     {
         $this->server->setClass(Server\Server::class);
         $test = $this->server->getFunctions();
-        $this->assertNotEmpty($test);
+        self::assertNotEmpty($test);
     }
 
     public function testBindingClassToServerShouldRegisterAllPublicMethods(): void
@@ -66,7 +66,7 @@ class ServerTest extends TestCase
             if ('_' === $method[0]) {
                 continue;
             }
-            $this->assertTrue(
+            self::assertTrue(
                 $test->hasMethod($method),
                 'Testing for method ' . $method . ' against ' . var_export($test, true)
             );
@@ -78,7 +78,7 @@ class ServerTest extends TestCase
         $object = new Server\Server();
         $this->server->setClass($object);
         $test = $this->server->getFunctions();
-        $this->assertNotEmpty($test);
+        self::assertNotEmpty($test);
     }
 
     public function testBindingObjectToServerShouldRegisterAllPublicMethods(): void
@@ -91,7 +91,7 @@ class ServerTest extends TestCase
             if ('_' === $method[0]) {
                 continue;
             }
-            $this->assertTrue(
+            self::assertTrue(
                 $test->hasMethod($method),
                 'Testing for method ' . $method . ' against ' . var_export($test, true)
             );
@@ -105,8 +105,8 @@ class ServerTest extends TestCase
         $methods    = $this->server->getFunctions();
         $zjsMethods = get_class_methods(Server\Server::class);
         $zjMethods  = get_class_methods(Json\Json::class);
-        $this->assertGreaterThan(count($zjsMethods), count($methods));
-        $this->assertGreaterThan(count($zjMethods), count($methods));
+        self::assertGreaterThan(count($zjsMethods), count($methods));
+        self::assertGreaterThan(count($zjMethods), count($methods));
     }
 
     public function testNamingCollisionsShouldResolveToLastRegisteredMethod(): void
@@ -114,15 +114,15 @@ class ServerTest extends TestCase
         $this->server->setClass(Request::class)
                      ->setClass(Response::class);
         $methods = $this->server->getFunctions();
-        $this->assertTrue($methods->hasMethod('toJson'));
+        self::assertTrue($methods->hasMethod('toJson'));
         $toJson = $methods->getMethod('toJson');
-        $this->assertEquals(Response::class, $toJson->getCallback()->getClass());
+        self::assertEquals(Response::class, $toJson->getCallback()->getClass());
     }
 
     public function testGetRequestShouldInstantiateRequestObjectByDefault(): void
     {
         $request = $this->server->getRequest();
-        $this->assertInstanceOf(Request::class, $request);
+        self::assertInstanceOf(Request::class, $request);
     }
 
     public function testShouldAllowSettingRequestObjectManually(): void
@@ -131,14 +131,14 @@ class ServerTest extends TestCase
         $new  = new Request();
         $this->server->setRequest($new);
         $test = $this->server->getRequest();
-        $this->assertSame($new, $test);
-        $this->assertNotSame($orig, $test);
+        self::assertSame($new, $test);
+        self::assertNotSame($orig, $test);
     }
 
     public function testGetResponseShouldInstantiateResponseObjectByDefault(): void
     {
         $response = $this->server->getResponse();
-        $this->assertInstanceOf(Response::class, $response);
+        self::assertInstanceOf(Response::class, $response);
     }
 
     public function testShouldAllowSettingResponseObjectManually(): void
@@ -147,37 +147,37 @@ class ServerTest extends TestCase
         $new  = new Response();
         $this->server->setResponse($new);
         $test = $this->server->getResponse();
-        $this->assertSame($new, $test);
-        $this->assertNotSame($orig, $test);
+        self::assertSame($new, $test);
+        self::assertNotSame($orig, $test);
     }
 
     public function testFaultShouldCreateErrorResponse(): void
     {
         $response = $this->server->getResponse();
-        $this->assertFalse($response->isError());
+        self::assertFalse($response->isError());
         $this->server->fault('error condition', -32000);
-        $this->assertTrue($response->isError());
+        self::assertTrue($response->isError());
         $error = $response->getError();
-        $this->assertEquals(-32000, $error->getCode());
-        $this->assertEquals('error condition', $error->getMessage());
+        self::assertEquals(-32000, $error->getCode());
+        self::assertEquals('error condition', $error->getMessage());
     }
 
     public function testResponseShouldBeEmittedAutomaticallyByDefault(): void
     {
-        $this->assertFalse($this->server->getReturnResponse());
+        self::assertFalse($this->server->getReturnResponse());
     }
 
     public function testShouldBeAbleToDisableAutomaticResponseEmission(): void
     {
         $this->testResponseShouldBeEmittedAutomaticallyByDefault();
         $this->server->setReturnResponse(true);
-        $this->assertTrue($this->server->getReturnResponse());
+        self::assertTrue($this->server->getReturnResponse());
     }
 
     public function testShouldBeAbleToRetrieveSmdObject(): void
     {
         $smd = $this->server->getServiceMap();
-        $this->assertInstanceOf(Server\Smd::class, $smd);
+        self::assertInstanceOf(Server\Smd::class, $smd);
     }
 
     public function testShouldBeAbleToSetArbitrarySmdMetadata(): void
@@ -189,12 +189,12 @@ class ServerTest extends TestCase
                      ->setId('foobar')
                      ->setDescription('This is a test service');
 
-        $this->assertEquals('POST', $this->server->getTransport());
-        $this->assertEquals('JSON-RPC-1.0', $this->server->getEnvelope());
-        $this->assertEquals('application/x-json', $this->server->getContentType());
-        $this->assertEquals('/foo/bar', $this->server->getTarget());
-        $this->assertEquals('foobar', $this->server->getId());
-        $this->assertEquals('This is a test service', $this->server->getDescription());
+        self::assertEquals('POST', $this->server->getTransport());
+        self::assertEquals('JSON-RPC-1.0', $this->server->getEnvelope());
+        self::assertEquals('application/x-json', $this->server->getContentType());
+        self::assertEquals('/foo/bar', $this->server->getTarget());
+        self::assertEquals('foobar', $this->server->getId());
+        self::assertEquals('This is a test service', $this->server->getDescription());
     }
 
     public function testSmdObjectRetrievedFromServerShouldReflectServerState(): void
@@ -208,23 +208,23 @@ class ServerTest extends TestCase
                      ->setId('foobar')
                      ->setDescription('This is a test service');
         $smd = $this->server->getServiceMap();
-        $this->assertEquals('POST', $this->server->getTransport());
-        $this->assertEquals('JSON-RPC-1.0', $this->server->getEnvelope());
-        $this->assertEquals('application/x-json', $this->server->getContentType());
-        $this->assertEquals('/foo/bar', $this->server->getTarget());
-        $this->assertEquals('foobar', $this->server->getId());
-        $this->assertEquals('This is a test service', $this->server->getDescription());
+        self::assertEquals('POST', $this->server->getTransport());
+        self::assertEquals('JSON-RPC-1.0', $this->server->getEnvelope());
+        self::assertEquals('application/x-json', $this->server->getContentType());
+        self::assertEquals('/foo/bar', $this->server->getTarget());
+        self::assertEquals('foobar', $this->server->getId());
+        self::assertEquals('This is a test service', $this->server->getDescription());
 
         $services = $smd->getServices();
-        $this->assertIsArray($services);
-        $this->assertNotEmpty($services);
-        $this->assertArrayHasKey('strtolower', $services);
+        self::assertIsArray($services);
+        self::assertNotEmpty($services);
+        self::assertArrayHasKey('strtolower', $services);
         $methods = get_class_methods(Server\Server::class);
         foreach ($methods as $method) {
             if ('_' === $method[0]) {
                 continue;
             }
-            $this->assertArrayHasKey($method, $services);
+            self::assertArrayHasKey($method, $services);
         }
     }
 
@@ -238,14 +238,14 @@ class ServerTest extends TestCase
                 ->setParams([true, 'foo', 'bar'])
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertFalse($response->isError());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertFalse($response->isError());
 
         $request->setMethod(__NAMESPACE__ . '\\TestAsset\\FooFunc')
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertFalse($response->isError());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertFalse($response->isError());
     }
 
     public function testHandleValidMethodWithNULLParamValueShouldWork(): void
@@ -258,8 +258,8 @@ class ServerTest extends TestCase
                 ->setParams([true, null, 'bar'])
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertFalse($response->isError());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertFalse($response->isError());
     }
 
     public function testHandleValidMethodWithTooFewParamsShouldPassDefaultsOrNullsForMissingParams(): void
@@ -271,13 +271,13 @@ class ServerTest extends TestCase
                 ->setParams([true])
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertFalse($response->isError());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertFalse($response->isError());
         $result = $response->getResult();
-        $this->assertIsArray($result);
-        $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, true));
-        $this->assertNull($result[2]);
+        self::assertIsArray($result);
+        self::assertCount(3, $result);
+        self::assertEquals('two', $result[1], var_export($result, true));
+        self::assertNull($result[2]);
     }
 
     public function testHandleValidMethodWithTooFewAssociativeParamsShouldPassDefaultsOrNullsForMissingParams(): void
@@ -289,13 +289,13 @@ class ServerTest extends TestCase
                 ->setParams(['one' => true])
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertFalse($response->isError());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertFalse($response->isError());
         $result = $response->getResult();
-        $this->assertIsArray($result);
-        $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, true));
-        $this->assertNull($result[2]);
+        self::assertIsArray($result);
+        self::assertCount(3, $result);
+        self::assertEquals('two', $result[1], var_export($result, true));
+        self::assertNull($result[2]);
     }
 
     public function testHandleValidMethodWithTooManyParamsShouldWork(): void
@@ -307,13 +307,13 @@ class ServerTest extends TestCase
                 ->setParams([true, 'foo', 'bar', 'baz'])
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertFalse($response->isError());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertFalse($response->isError());
         $result = $response->getResult();
-        $this->assertIsArray($result);
-        $this->assertCount(3, $result);
-        $this->assertEquals('foo', $result[1]);
-        $this->assertEquals('bar', $result[2]);
+        self::assertIsArray($result);
+        self::assertCount(3, $result);
+        self::assertEquals('foo', $result[1]);
+        self::assertEquals('bar', $result[2]);
     }
 
     public function testHandleShouldAllowNamedParamsInAnyOrder1(): void
@@ -331,10 +331,10 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $result   = $response->getResult();
 
-        $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals(2, $result[1]);
-        $this->assertEquals(3, $result[2]);
+        self::assertIsArray($result);
+        self::assertEquals(1, $result[0]);
+        self::assertEquals(2, $result[1]);
+        self::assertEquals(3, $result[2]);
     }
 
     public function testHandleShouldAllowNamedParamsInAnyOrder2(): void
@@ -352,10 +352,10 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $result   = $response->getResult();
 
-        $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals(2, $result[1]);
-        $this->assertEquals(3, $result[2]);
+        self::assertIsArray($result);
+        self::assertEquals(1, $result[0]);
+        self::assertEquals(2, $result[1]);
+        self::assertEquals(3, $result[2]);
     }
 
     public function testHandleValidWithoutRequiredParamShouldReturnError(): void
@@ -371,9 +371,9 @@ class ServerTest extends TestCase
                 ->setId('foo');
         $response = $this->server->handle();
 
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertTrue($response->isError());
+        self::assertEquals(Server\Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
     }
 
     public function testHandleRequestWithErrorsShouldReturnErrorResponse(): void
@@ -381,9 +381,9 @@ class ServerTest extends TestCase
         $this->server->setClass(TestAsset\Foo::class)
                      ->setReturnResponse(true);
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_INVALID_REQUEST, $response->getError()->getCode());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertTrue($response->isError());
+        self::assertEquals(Server\Error::ERROR_INVALID_REQUEST, $response->getError()->getCode());
     }
 
     public function testHandleRequestWithInvalidMethodShouldReturnErrorResponse(): void
@@ -394,9 +394,9 @@ class ServerTest extends TestCase
         $request->setMethod('bogus')
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_INVALID_METHOD, $response->getError()->getCode());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertTrue($response->isError());
+        self::assertEquals(Server\Error::ERROR_INVALID_METHOD, $response->getError()->getCode());
     }
 
     public function testHandleRequestWithExceptionShouldReturnErrorResponse(): void
@@ -407,10 +407,10 @@ class ServerTest extends TestCase
         $request->setMethod('baz')
                 ->setId('foo');
         $response = $this->server->handle();
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertTrue($response->isError());
-        $this->assertEquals(Server\Error::ERROR_OTHER, $response->getError()->getCode());
-        $this->assertEquals('application error', $response->getError()->getMessage());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertTrue($response->isError());
+        self::assertEquals(Server\Error::ERROR_OTHER, $response->getError()->getCode());
+        self::assertEquals('application error', $response->getError()->getMessage());
     }
 
     public function testHandleShouldEmitResponseByDefault(): void
@@ -425,13 +425,13 @@ class ServerTest extends TestCase
         $buffer = ob_get_clean();
 
         $decoded = Json\Json::decode($buffer, Json\Json::TYPE_ARRAY);
-        $this->assertIsArray($decoded);
-        $this->assertArrayHasKey('result', $decoded);
-        $this->assertArrayHasKey('id', $decoded);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('result', $decoded);
+        self::assertArrayHasKey('id', $decoded);
 
         $response = $this->server->getResponse();
-        $this->assertEquals($response->getResult(), $decoded['result']);
-        $this->assertEquals($response->getId(), $decoded['id']);
+        self::assertEquals($response->getResult(), $decoded['result']);
+        self::assertEquals($response->getId(), $decoded['id']);
     }
 
     public function testResponseShouldBeEmptyWhenRequestHasNoId(): void
@@ -444,7 +444,7 @@ class ServerTest extends TestCase
         $this->server->handle();
         $buffer = ob_get_clean();
 
-        $this->assertEmpty($buffer);
+        self::assertEmpty($buffer);
     }
 
     public function testLoadFunctionsShouldLoadResultOfGetFunctions(): void
@@ -453,7 +453,7 @@ class ServerTest extends TestCase
         $functions = $this->server->getFunctions();
         $server    = new Server\Server();
         $server->loadFunctions($functions);
-        $this->assertEquals($functions->toArray(), $server->getFunctions()->toArray());
+        self::assertEquals($functions->toArray(), $server->getFunctions()->toArray());
     }
 
     /**
@@ -475,14 +475,14 @@ class ServerTest extends TestCase
 
         $decoded = Json\Json::decode($buffer, Json\Json::TYPE_ARRAY);
 
-        $this->assertIsArray($decoded);
-        $this->assertArrayHasKey('result', $decoded);
-        $this->assertArrayHasKey('id', $decoded);
-        $this->assertContains('unique', $decoded['result']);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('result', $decoded);
+        self::assertArrayHasKey('id', $decoded);
+        self::assertContains('unique', $decoded['result']);
 
         $response = $this->server->getResponse();
-        $this->assertEquals($response->getResult(), $decoded['result']);
-        $this->assertEquals($response->getId(), $decoded['id']);
+        self::assertEquals($response->getResult(), $decoded['result']);
+        self::assertEquals($response->getId(), $decoded['id']);
     }
 
     /**
@@ -502,10 +502,10 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $result   = $response->getResult();
 
-        $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals(2, $result[1]);
-        $this->assertEquals(null, $result[2]);
+        self::assertIsArray($result);
+        self::assertEquals(1, $result[0]);
+        self::assertEquals(2, $result[1]);
+        self::assertEquals(null, $result[2]);
     }
 
     /**
@@ -525,10 +525,10 @@ class ServerTest extends TestCase
         $response = $this->server->handle();
         $result   = $response->getResult();
 
-        $this->assertIsArray($result);
-        $this->assertEquals(1, $result[0]);
-        $this->assertEquals('two', $result[1]);
-        $this->assertEquals(3, $result[2]);
+        self::assertIsArray($result);
+        self::assertEquals(1, $result[0]);
+        self::assertEquals('two', $result[1]);
+        self::assertEquals(3, $result[2]);
     }
 
     public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys(): void
@@ -542,7 +542,7 @@ class ServerTest extends TestCase
         $server->handle();
 
         $response = $server->getResponse();
-        $this->assertEquals(Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
+        self::assertEquals(Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
     }
 
     public function testResponseShouldBeInvalidWhenRequestHasLessRequiredParametersPassedWithoutKeys1(): void
@@ -555,7 +555,7 @@ class ServerTest extends TestCase
                 ->setParams([true]);
         $server->handle();
         $response = $server->getResponse();
-        $this->assertNotEmpty($response->getError());
-        $this->assertEquals(Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
+        self::assertNotEmpty($response->getError());
+        self::assertEquals(Error::ERROR_INVALID_PARAMS, $response->getError()->getCode());
     }
 }

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -68,7 +68,7 @@ class ServerTest extends TestCase
             }
             $this->assertTrue(
                 $test->hasMethod($method),
-                'Testing for method ' . $method . ' against ' . var_export($test, 1)
+                'Testing for method ' . $method . ' against ' . var_export($test, true)
             );
         }
     }
@@ -93,7 +93,7 @@ class ServerTest extends TestCase
             }
             $this->assertTrue(
                 $test->hasMethod($method),
-                'Testing for method ' . $method . ' against ' . var_export($test, 1)
+                'Testing for method ' . $method . ' against ' . var_export($test, true)
             );
         }
     }
@@ -276,7 +276,7 @@ class ServerTest extends TestCase
         $result = $response->getResult();
         $this->assertIsArray($result);
         $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, 1));
+        $this->assertEquals('two', $result[1], var_export($result, true));
         $this->assertNull($result[2]);
     }
 
@@ -294,7 +294,7 @@ class ServerTest extends TestCase
         $result = $response->getResult();
         $this->assertIsArray($result);
         $this->assertCount(3, $result);
-        $this->assertEquals('two', $result[1], var_export($result, 1));
+        $this->assertEquals('two', $result[1], var_export($result, true));
         $this->assertNull($result[2]);
     }
 

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -62,13 +62,15 @@ class ServiceTest extends TestCase
         $this->service->setName('rpc.Foo');
     }
 
-    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar()
+    // phpcs:ignore
+    public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar(): void
     {
         $this->service->setName('rpcFoo');
         $this->assertEquals('rpcFoo', $this->service->getName());
     }
 
-    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase()
+    // phpcs:ignore
+    public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase(): void
     {
         $this->service->setName('RpcFoo');
         $this->assertEquals('RpcFoo', $this->service->getName());

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -52,7 +52,7 @@ class ServiceTest extends TestCase
     public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatStartingWithUnderscore(): void
     {
         $this->service->setName('_getMyProperty');
-        $this->assertEquals('_getMyProperty', $this->service->getName());
+        self::assertEquals('_getMyProperty', $this->service->getName());
     }
 
     public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpc(): void
@@ -66,35 +66,35 @@ class ServiceTest extends TestCase
     public function testSettingNameShouldThrowExceptionWhenContainingInvalidFormatStartingWithRpcWithoutPeriodChar(): void
     {
         $this->service->setName('rpcFoo');
-        $this->assertEquals('rpcFoo', $this->service->getName());
+        self::assertEquals('rpcFoo', $this->service->getName());
     }
 
     // phpcs:ignore
     public function testSettingNameShouldNotThrowExceptionWhenContainingInvalidFormatStartingWithRpcInsensitiveCase(): void
     {
         $this->service->setName('RpcFoo');
-        $this->assertEquals('RpcFoo', $this->service->getName());
+        self::assertEquals('RpcFoo', $this->service->getName());
     }
 
     public function testSettingNameShouldNotThrowExceptionWhenContainingValidFormatContainingRpc(): void
     {
         $this->service->setName('_rpcFoo');
-        $this->assertEquals('_rpcFoo', $this->service->getName());
+        self::assertEquals('_rpcFoo', $this->service->getName());
 
         $this->service->setName('MyRpcFoo');
-        $this->assertEquals('MyRpcFoo', $this->service->getName());
+        self::assertEquals('MyRpcFoo', $this->service->getName());
     }
 
     public function testNameAccessorsShouldWorkWithNormalInput(): void
     {
-        $this->assertEquals('foo', $this->service->getName());
+        self::assertEquals('foo', $this->service->getName());
         $this->service->setName('bar');
-        $this->assertEquals('bar', $this->service->getName());
+        self::assertEquals('bar', $this->service->getName());
     }
 
     public function testTransportShouldDefaultToPost(): void
     {
-        $this->assertEquals('POST', $this->service->getTransport());
+        self::assertEquals('POST', $this->service->getTransport());
     }
 
     public function testSettingTransportThrowsExceptionWhenSetToGet(): void
@@ -114,19 +114,19 @@ class ServiceTest extends TestCase
     public function testTransportAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->service->setTransport('POST');
-        $this->assertEquals('POST', $this->service->getTransport());
+        self::assertEquals('POST', $this->service->getTransport());
     }
 
     public function testTargetShouldBeNullInitially(): void
     {
-        $this->assertNull($this->service->getTarget());
+        self::assertNull($this->service->getTarget());
     }
 
     public function testTargetAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testTargetShouldBeNullInitially();
         $this->service->setTarget('foo');
-        $this->assertEquals('foo', $this->service->getTarget());
+        self::assertEquals('foo', $this->service->getTarget());
     }
 
     public function testTargetAccessorsShouldNormalizeToString(): void
@@ -134,43 +134,43 @@ class ServiceTest extends TestCase
         $this->testTargetShouldBeNullInitially();
         $this->service->setTarget(123);
         $value = $this->service->getTarget();
-        $this->assertIsString($value);
-        $this->assertEquals((string) 123, $value);
+        self::assertIsString($value);
+        self::assertEquals((string) 123, $value);
     }
 
     public function testEnvelopeShouldBeJSONRpc1CompliantByDefault(): void
     {
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
+        self::assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
     }
 
     public function testEnvelopeShouldOnlyComplyWithJSONRpc1And2(): void
     {
         $this->testEnvelopeShouldBeJSONRpc1CompliantByDefault();
         $this->service->setEnvelope(Smd::ENV_JSONRPC_2);
-        $this->assertEquals(Smd::ENV_JSONRPC_2, $this->service->getEnvelope());
+        self::assertEquals(Smd::ENV_JSONRPC_2, $this->service->getEnvelope());
         $this->service->setEnvelope(Smd::ENV_JSONRPC_1);
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
+        self::assertEquals(Smd::ENV_JSONRPC_1, $this->service->getEnvelope());
         try {
             $this->service->setEnvelope('JSON-P');
             $this->fail('Should not be able to set non-JSON-RPC spec envelopes');
         } catch (Exception\InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid envelope', $e->getMessage());
+            self::assertStringContainsString('Invalid envelope', $e->getMessage());
         }
     }
 
     public function testShouldHaveNoParamsByDefault(): void
     {
         $params = $this->service->getParams();
-        $this->assertEmpty($params);
+        self::assertEmpty($params);
     }
 
     public function testShouldBeAbleToAddParamsByTypeOnly(): void
     {
         $this->service->addParam('integer');
         $params = $this->service->getParams();
-        $this->assertCount(1, $params);
+        self::assertCount(1, $params);
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type']);
+        self::assertEquals('integer', $param['type']);
     }
 
     public function testParamsShouldAcceptArrayOfTypes(): void
@@ -180,8 +180,8 @@ class ServiceTest extends TestCase
         $params = $this->service->getParams();
         $param  = array_shift($params);
         $test   = $param['type'];
-        $this->assertIsArray($test);
-        $this->assertEquals($type, $test);
+        self::assertIsArray($test);
+        self::assertEquals($type, $test);
     }
 
     public function testInvalidParamTypeShouldThrowException(): void
@@ -198,14 +198,14 @@ class ServiceTest extends TestCase
                       ->addParam('boolean', [], 3);
         $params = $this->service->getParams();
 
-        $this->assertCount(3, $params);
+        self::assertCount(3, $params);
 
         $param = array_shift($params);
-        $this->assertEquals('string', $param['type'], var_export($params, true));
+        self::assertEquals('string', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type'], var_export($params, true));
+        self::assertEquals('boolean', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type'], var_export($params, true));
+        self::assertEquals('integer', $param['type'], var_export($params, true));
     }
 
     public function testShouldBeAbleToAddArbitraryParamOptions(): void
@@ -221,10 +221,10 @@ class ServiceTest extends TestCase
         );
         $params = $this->service->getParams();
         $param  = array_shift($params);
-        $this->assertEquals('foo', $param['name']);
-        $this->assertFalse($param['optional']);
-        $this->assertEquals(1, $param['default']);
-        $this->assertEquals('Foo parameter', $param['description']);
+        self::assertEquals('foo', $param['name']);
+        self::assertFalse($param['optional']);
+        self::assertEquals(1, $param['default']);
+        self::assertEquals('Foo parameter', $param['description']);
     }
 
     public function testShouldBeAbleToAddMultipleParamsAtOnce(): void
@@ -236,43 +236,43 @@ class ServiceTest extends TestCase
         ]);
         $params = $this->service->getParams();
 
-        $this->assertCount(3, $params);
+        self::assertCount(3, $params);
         $param = array_shift($params);
-        $this->assertEquals('string', $param['type']);
-        $this->assertEquals('foo', $param['name']);
+        self::assertEquals('string', $param['type']);
+        self::assertEquals('foo', $param['name']);
 
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type']);
+        self::assertEquals('boolean', $param['type']);
 
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type']);
+        self::assertEquals('integer', $param['type']);
     }
 
     public function testSetparamsShouldOverwriteExistingParams(): void
     {
         $this->testShouldBeAbleToAddMultipleParamsAtOnce();
         $params = $this->service->getParams();
-        $this->assertCount(3, $params);
+        self::assertCount(3, $params);
 
         $this->service->setParams([
             ['type' => 'string'],
             ['type' => 'integer'],
         ]);
         $test = $this->service->getParams();
-        $this->assertNotEquals($params, $test);
-        $this->assertCount(2, $test);
+        self::assertNotEquals($params, $test);
+        self::assertCount(2, $test);
     }
 
     public function testReturnShouldBeNullByDefault(): void
     {
-        $this->assertNull($this->service->getReturn());
+        self::assertNull($this->service->getReturn());
     }
 
     public function testReturnAccessorsShouldWorkWithNormalInput(): void
     {
         $this->testReturnShouldBeNullByDefault();
         $this->service->setReturn('integer');
-        $this->assertEquals('integer', $this->service->getReturn());
+        self::assertEquals('integer', $this->service->getReturn());
     }
 
     public function testReturnAccessorsShouldAllowArrayOfTypes(): void
@@ -280,7 +280,7 @@ class ServiceTest extends TestCase
         $this->testReturnShouldBeNullByDefault();
         $type = ['integer', 'string'];
         $this->service->setReturn($type);
-        $this->assertEquals($type, $this->service->getReturn());
+        self::assertEquals($type, $this->service->getReturn());
     }
 
     public function testInvalidReturnTypeShouldThrowException(): void
@@ -303,8 +303,8 @@ class ServiceTest extends TestCase
         $json = $this->service->toJSON();
         $smd  = Json::decode($json, Json::TYPE_ARRAY);
 
-        $this->assertArrayHasKey('foo', $smd);
-        $this->assertIsArray($smd['foo']);
+        self::assertArrayHasKey('foo', $smd);
+        self::assertIsArray($smd['foo']);
 
         $this->validateSmdArray($smd['foo']);
     }
@@ -323,23 +323,23 @@ class ServiceTest extends TestCase
 
     public function validateSmdArray(array $smd): void
     {
-        $this->assertArrayHasKey('transport', $smd);
-        $this->assertEquals('POST', $smd['transport']);
+        self::assertArrayHasKey('transport', $smd);
+        self::assertEquals('POST', $smd['transport']);
 
-        $this->assertArrayHasKey('envelope', $smd);
-        $this->assertEquals(Smd::ENV_JSONRPC_2, $smd['envelope']);
+        self::assertArrayHasKey('envelope', $smd);
+        self::assertEquals(Smd::ENV_JSONRPC_2, $smd['envelope']);
 
-        $this->assertArrayHasKey('parameters', $smd);
+        self::assertArrayHasKey('parameters', $smd);
         $params = $smd['parameters'];
-        $this->assertCount(3, $params);
+        self::assertCount(3, $params);
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type']);
+        self::assertEquals('boolean', $param['type']);
         $param = array_shift($params);
-        $this->assertEquals('array', $param['type']);
+        self::assertEquals('array', $param['type']);
         $param = array_shift($params);
-        $this->assertEquals('object', $param['type']);
+        self::assertEquals('object', $param['type']);
 
-        $this->assertArrayHasKey('returns', $smd);
-        $this->assertEquals('boolean', $smd['returns']);
+        self::assertArrayHasKey('returns', $smd);
+        self::assertEquals('boolean', $smd['returns']);
     }
 }

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -1,25 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\Smd;
 
+use Laminas\Json\Json;
 use Laminas\Json\Server\Exception;
 use Laminas\Json\Server\Smd;
 use Laminas\Json\Server\Smd\Service;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function array_shift;
+use function var_export;
+
 class ServiceTest extends TestCase
 {
-    /**
-     * @var Service
-     */
+    /** @var Service */
     protected $service;
 
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -171,7 +173,7 @@ class ServiceTest extends TestCase
 
     public function testParamsShouldAcceptArrayOfTypes(): void
     {
-        $type   = ['integer', 'string'];
+        $type = ['integer', 'string'];
         $this->service->addParam($type);
         $params = $this->service->getParams();
         $param  = array_shift($params);
@@ -184,7 +186,7 @@ class ServiceTest extends TestCase
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid param type');
-        $this->service->addParam(new stdClass);
+        $this->service->addParam(new stdClass());
     }
 
     public function testShouldBeAbleToOrderParams(): void
@@ -283,7 +285,7 @@ class ServiceTest extends TestCase
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid param type');
-        $this->service->setReturn(new stdClass);
+        $this->service->setReturn(new stdClass());
     }
 
     public function testToArrayShouldCreateSmdCompatibleHash(): void
@@ -297,7 +299,7 @@ class ServiceTest extends TestCase
     {
         $this->setupSmdValidationObject();
         $json = $this->service->toJSON();
-        $smd  = \Laminas\Json\Json::decode($json, \Laminas\Json\Json::TYPE_ARRAY);
+        $smd  = Json::decode($json, Json::TYPE_ARRAY);
 
         $this->assertArrayHasKey('foo', $smd);
         $this->assertIsArray($smd['foo']);

--- a/test/Smd/ServiceTest.php
+++ b/test/Smd/ServiceTest.php
@@ -199,11 +199,11 @@ class ServiceTest extends TestCase
         $this->assertCount(3, $params);
 
         $param = array_shift($params);
-        $this->assertEquals('string', $param['type'], var_export($params, 1));
+        $this->assertEquals('string', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('boolean', $param['type'], var_export($params, 1));
+        $this->assertEquals('boolean', $param['type'], var_export($params, true));
         $param = array_shift($params);
-        $this->assertEquals('integer', $param['type'], var_export($params, 1));
+        $this->assertEquals('integer', $param['type'], var_export($params, true));
     }
 
     public function testShouldBeAbleToAddArbitraryParamOptions(): void

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -1,25 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server;
 
 use Laminas\Json;
 use Laminas\Json\Server\Exception\InvalidArgumentException;
 use Laminas\Json\Server\Exception\RuntimeException;
 use Laminas\Json\Server\Smd;
+use Laminas\Json\Server\Smd\Service;
 use PHPUnit\Framework\TestCase;
+
+use function array_keys;
+use function array_shift;
+use function array_values;
+use function uniqid;
 
 class SmdTest extends TestCase
 {
-    /**
-     * @var Smd
-     */
+    /** @var Smd */
     protected $smd;
 
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before a test is executed.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -171,7 +175,7 @@ class SmdTest extends TestCase
         ];
         $this->smd->addService($service);
         $foo = $this->smd->getService('foo');
-        $this->assertInstanceOf('Laminas\Json\Server\Smd\Service', $foo);
+        $this->assertInstanceOf(Service::class, $foo);
         $this->assertEquals('foo', $foo->getName());
     }
 
@@ -179,7 +183,7 @@ class SmdTest extends TestCase
     {
         $service = new Smd\Service('foo');
         $this->smd->addService($service);
-        $test    = new Smd\Service('foo');
+        $test = new Smd\Service('foo');
         try {
             $this->smd->addService($test);
             $this->fail('Adding service with existing service name should throw exception');
@@ -202,9 +206,9 @@ class SmdTest extends TestCase
 
     public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfServiceObjects(): void
     {
-        $one   = new Smd\Service('one');
-        $two   = new Smd\Service('two');
-        $three = new Smd\Service('three');
+        $one      = new Smd\Service('one');
+        $two      = new Smd\Service('two');
+        $three    = new Smd\Service('three');
         $services = [$one, $two, $three];
         $this->smd->addServices($services);
         $test = $this->smd->getServices();
@@ -225,7 +229,7 @@ class SmdTest extends TestCase
 
     public function testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays(): void
     {
-        $two = new Smd\Service('two');
+        $two      = new Smd\Service('two');
         $services = [
             ['name' => 'one'],
             $two,
@@ -240,7 +244,7 @@ class SmdTest extends TestCase
     public function testSetServicesShouldOverwriteExistingServices(): void
     {
         $this->testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays();
-        $five = new Smd\Service('five');
+        $five     = new Smd\Service('five');
         $services = [
             ['name' => 'four'],
             $five,
@@ -387,7 +391,7 @@ class SmdTest extends TestCase
         $smdSource->setTarget('http://foo');
         $smdSource->setTransport('POST');
         $smdSource->setServices([
-            ['name' => 'foo']
+            ['name' => 'foo'],
         ]);
 
         $smdDestination = new Smd();

--- a/test/SmdTest.php
+++ b/test/SmdTest.php
@@ -32,13 +32,13 @@ class SmdTest extends TestCase
 
     public function testTransportShouldDefaultToPost(): void
     {
-        $this->assertEquals('POST', $this->smd->getTransport());
+        self::assertEquals('POST', $this->smd->getTransport());
     }
 
     public function testTransportAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->smd->setTransport('POST');
-        $this->assertEquals('POST', $this->smd->getTransport());
+        self::assertEquals('POST', $this->smd->getTransport());
     }
 
     public function testTransportShouldBeLimitedToPost(): void
@@ -48,23 +48,23 @@ class SmdTest extends TestCase
                 $this->smd->setTransport($transport);
                 $this->fail('Invalid transport should throw exception');
             } catch (InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid transport', $e->getMessage());
+                self::assertStringContainsString('Invalid transport', $e->getMessage());
             }
         }
     }
 
     public function testEnvelopeShouldDefaultToJSONRpcVersion1(): void
     {
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
+        self::assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
     public function testEnvelopeAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testEnvelopeShouldDefaultToJSONRpcVersion1();
         $this->smd->setEnvelope(Smd::ENV_JSONRPC_2);
-        $this->assertEquals(Smd::ENV_JSONRPC_2, $this->smd->getEnvelope());
+        self::assertEquals(Smd::ENV_JSONRPC_2, $this->smd->getEnvelope());
         $this->smd->setEnvelope(Smd::ENV_JSONRPC_1);
-        $this->assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
+        self::assertEquals(Smd::ENV_JSONRPC_1, $this->smd->getEnvelope());
     }
 
     public function testEnvelopeShouldBeLimitedToJSONRpcVersions(): void
@@ -74,21 +74,21 @@ class SmdTest extends TestCase
                 $this->smd->setEnvelope($env);
                 $this->fail('Invalid envelope type should throw exception');
             } catch (InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid envelope', $e->getMessage());
+                self::assertStringContainsString('Invalid envelope', $e->getMessage());
             }
         }
     }
 
     public function testContentTypeShouldDefaultToApplicationJSON(): void
     {
-        $this->assertEquals('application/json', $this->smd->getContentType());
+        self::assertEquals('application/json', $this->smd->getContentType());
     }
 
     public function testContentTypeAccessorsShouldWorkUnderNormalInput(): void
     {
         foreach (['text/json', 'text/plain', 'application/x-json'] as $type) {
             $this->smd->setContentType($type);
-            $this->assertEquals($type, $this->smd->getContentType());
+            self::assertEquals($type, $this->smd->getContentType());
         }
     }
 
@@ -99,73 +99,73 @@ class SmdTest extends TestCase
                 $this->smd->setContentType($type);
                 $this->fail('Invalid content type should raise exception');
             } catch (InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid content type', $e->getMessage());
+                self::assertStringContainsString('Invalid content type', $e->getMessage());
             }
         }
     }
 
     public function testTargetShouldDefaultToNull(): void
     {
-        $this->assertNull($this->smd->getTarget());
+        self::assertNull($this->smd->getTarget());
     }
 
     public function testTargetAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testTargetShouldDefaultToNull();
         $this->smd->setTarget('foo');
-        $this->assertEquals('foo', $this->smd->getTarget());
+        self::assertEquals('foo', $this->smd->getTarget());
     }
 
     public function testIdShouldDefaultToNull(): void
     {
-        $this->assertNull($this->smd->getId());
+        self::assertNull($this->smd->getId());
     }
 
     public function testIdAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testIdShouldDefaultToNull();
         $this->smd->setId('foo');
-        $this->assertEquals('foo', $this->smd->getId());
+        self::assertEquals('foo', $this->smd->getId());
     }
 
     public function testDescriptionShouldDefaultToNull(): void
     {
-        $this->assertNull($this->smd->getDescription());
+        self::assertNull($this->smd->getDescription());
     }
 
     public function testDescriptionAccessorsShouldWorkUnderNormalInput(): void
     {
         $this->testDescriptionShouldDefaultToNull();
         $this->smd->setDescription('foo');
-        $this->assertEquals('foo', $this->smd->getDescription());
+        self::assertEquals('foo', $this->smd->getDescription());
     }
 
     public function testDojoCompatibilityShouldBeDisabledByDefault(): void
     {
-        $this->assertFalse($this->smd->isDojoCompatible());
+        self::assertFalse($this->smd->isDojoCompatible());
     }
 
     public function testDojoCompatibilityFlagShouldBeMutable(): void
     {
         $this->testDojoCompatibilityShouldBeDisabledByDefault();
         $this->smd->setDojoCompatible(true);
-        $this->assertTrue($this->smd->isDojoCompatible());
+        self::assertTrue($this->smd->isDojoCompatible());
         $this->smd->setDojoCompatible(false);
-        $this->assertFalse($this->smd->isDojoCompatible());
+        self::assertFalse($this->smd->isDojoCompatible());
     }
 
     public function testServicesShouldBeEmptyByDefault(): void
     {
         $services = $this->smd->getServices();
-        $this->assertIsArray($services);
-        $this->assertEmpty($services);
+        self::assertIsArray($services);
+        self::assertEmpty($services);
     }
 
     public function testShouldBeAbleToUseServiceObjectToAddService(): void
     {
         $service = new Smd\Service('foo');
         $this->smd->addService($service);
-        $this->assertSame($service, $this->smd->getService('foo'));
+        self::assertSame($service, $this->smd->getService('foo'));
     }
 
     public function testShouldBeAbleToUseArrayToAddService(): void
@@ -175,8 +175,8 @@ class SmdTest extends TestCase
         ];
         $this->smd->addService($service);
         $foo = $this->smd->getService('foo');
-        $this->assertInstanceOf(Service::class, $foo);
-        $this->assertEquals('foo', $foo->getName());
+        self::assertInstanceOf(Service::class, $foo);
+        self::assertEquals('foo', $foo->getName());
     }
 
     public function testAddingServiceWithExistingServiceNameShouldThrowException(): void
@@ -188,7 +188,7 @@ class SmdTest extends TestCase
             $this->smd->addService($test);
             $this->fail('Adding service with existing service name should throw exception');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('already register', $e->getMessage());
+            self::assertStringContainsString('already register', $e->getMessage());
         }
     }
 
@@ -199,7 +199,7 @@ class SmdTest extends TestCase
                 $this->smd->addService($service);
                 $this->fail('Attempt to register invalid service should throw exception');
             } catch (InvalidArgumentException $e) {
-                $this->assertStringContainsString('Invalid service', $e->getMessage());
+                self::assertStringContainsString('Invalid service', $e->getMessage());
             }
         }
     }
@@ -212,7 +212,7 @@ class SmdTest extends TestCase
         $services = [$one, $two, $three];
         $this->smd->addServices($services);
         $test = $this->smd->getServices();
-        $this->assertSame($services, array_values($test));
+        self::assertSame($services, array_values($test));
     }
 
     public function testShouldBeAbleToAddManyServicesAtOnceWithArrayOfArrays(): void
@@ -224,7 +224,7 @@ class SmdTest extends TestCase
         ];
         $this->smd->addServices($services);
         $test = $this->smd->getServices();
-        $this->assertSame(['one', 'two', 'three'], array_keys($test));
+        self::assertSame(['one', 'two', 'three'], array_keys($test));
     }
 
     public function testShouldBeAbleToAddManyServicesAtOnceWithMixedArrayOfObjectsAndArrays(): void
@@ -237,8 +237,8 @@ class SmdTest extends TestCase
         ];
         $this->smd->addServices($services);
         $test = $this->smd->getServices();
-        $this->assertSame(['one', 'two', 'three'], array_keys($test));
-        $this->assertEquals($two, $test['two']);
+        self::assertSame(['one', 'two', 'three'], array_keys($test));
+        self::assertEquals($two, $test['two']);
     }
 
     public function testSetServicesShouldOverwriteExistingServices(): void
@@ -252,8 +252,8 @@ class SmdTest extends TestCase
         ];
         $this->smd->setServices($services);
         $test = $this->smd->getServices();
-        $this->assertSame(['four', 'five', 'six'], array_keys($test));
-        $this->assertEquals($five, $test['five']);
+        self::assertSame(['four', 'five', 'six'], array_keys($test));
+        self::assertEquals($five, $test['five']);
     }
 
     public function testShouldBeAbleToRetrieveServiceByName(): void
@@ -264,8 +264,8 @@ class SmdTest extends TestCase
     public function testShouldBeAbleToRemoveServiceByName(): void
     {
         $this->testShouldBeAbleToUseServiceObjectToAddService();
-        $this->assertTrue($this->smd->removeService('foo'));
-        $this->assertFalse($this->smd->getService('foo'));
+        self::assertTrue($this->smd->removeService('foo'));
+        self::assertFalse($this->smd->getService('foo'));
     }
 
     public function testShouldBeAbleToCastToArray(): void
@@ -282,34 +282,34 @@ class SmdTest extends TestCase
         $this->smd->setOptions($options);
         $smd = $this->smd->toDojoArray();
 
-        $this->assertIsArray($smd);
+        self::assertIsArray($smd);
 
-        $this->assertArrayHasKey('SMDVersion', $smd);
-        $this->assertArrayHasKey('serviceType', $smd);
-        $this->assertArrayHasKey('methods', $smd);
+        self::assertArrayHasKey('SMDVersion', $smd);
+        self::assertArrayHasKey('serviceType', $smd);
+        self::assertArrayHasKey('methods', $smd);
 
-        $this->assertEquals('.1', $smd['SMDVersion']);
-        $this->assertEquals('JSON-RPC', $smd['serviceType']);
+        self::assertEquals('.1', $smd['SMDVersion']);
+        self::assertEquals('JSON-RPC', $smd['serviceType']);
         $methods = $smd['methods'];
-        $this->assertCount(2, $methods);
+        self::assertCount(2, $methods);
 
         $foo = array_shift($methods);
-        $this->assertArrayHasKey('name', $foo);
-        $this->assertArrayHasKey('serviceURL', $foo);
-        $this->assertArrayHasKey('parameters', $foo);
-        $this->assertEquals('foo', $foo['name']);
-        $this->assertEquals($this->smd->getTarget(), $foo['serviceURL']);
-        $this->assertIsArray($foo['parameters']);
-        $this->assertCount(1, $foo['parameters']);
+        self::assertArrayHasKey('name', $foo);
+        self::assertArrayHasKey('serviceURL', $foo);
+        self::assertArrayHasKey('parameters', $foo);
+        self::assertEquals('foo', $foo['name']);
+        self::assertEquals($this->smd->getTarget(), $foo['serviceURL']);
+        self::assertIsArray($foo['parameters']);
+        self::assertCount(1, $foo['parameters']);
 
         $bar = array_shift($methods);
-        $this->assertArrayHasKey('name', $bar);
-        $this->assertArrayHasKey('serviceURL', $bar);
-        $this->assertArrayHasKey('parameters', $bar);
-        $this->assertEquals('bar', $bar['name']);
-        $this->assertEquals($this->smd->getTarget(), $bar['serviceURL']);
-        $this->assertIsArray($bar['parameters']);
-        $this->assertCount(1, $bar['parameters']);
+        self::assertArrayHasKey('name', $bar);
+        self::assertArrayHasKey('serviceURL', $bar);
+        self::assertArrayHasKey('parameters', $bar);
+        self::assertEquals('bar', $bar['name']);
+        self::assertEquals($this->smd->getTarget(), $bar['serviceURL']);
+        self::assertIsArray($bar['parameters']);
+        self::assertCount(1, $bar['parameters']);
     }
 
     public function testShouldBeAbleToRenderAsJSON(): void
@@ -356,26 +356,26 @@ class SmdTest extends TestCase
 
     public function validateServiceArray(array $smd, array $options): void
     {
-        $this->assertIsArray($smd);
+        self::assertIsArray($smd);
 
-        $this->assertArrayHasKey('SMDVersion', $smd);
-        $this->assertArrayHasKey('target', $smd);
-        $this->assertArrayHasKey('id', $smd);
-        $this->assertArrayHasKey('transport', $smd);
-        $this->assertArrayHasKey('envelope', $smd);
-        $this->assertArrayHasKey('contentType', $smd);
-        $this->assertArrayHasKey('services', $smd);
+        self::assertArrayHasKey('SMDVersion', $smd);
+        self::assertArrayHasKey('target', $smd);
+        self::assertArrayHasKey('id', $smd);
+        self::assertArrayHasKey('transport', $smd);
+        self::assertArrayHasKey('envelope', $smd);
+        self::assertArrayHasKey('contentType', $smd);
+        self::assertArrayHasKey('services', $smd);
 
-        $this->assertEquals(Smd::SMD_VERSION, $smd['SMDVersion']);
-        $this->assertEquals($options['target'], $smd['target']);
-        $this->assertEquals($options['id'], $smd['id']);
-        $this->assertEquals($this->smd->getTransport(), $smd['transport']);
-        $this->assertEquals($this->smd->getEnvelope(), $smd['envelope']);
-        $this->assertEquals($this->smd->getContentType(), $smd['contentType']);
+        self::assertEquals(Smd::SMD_VERSION, $smd['SMDVersion']);
+        self::assertEquals($options['target'], $smd['target']);
+        self::assertEquals($options['id'], $smd['id']);
+        self::assertEquals($this->smd->getTransport(), $smd['transport']);
+        self::assertEquals($this->smd->getEnvelope(), $smd['envelope']);
+        self::assertEquals($this->smd->getContentType(), $smd['contentType']);
         $services = $smd['services'];
-        $this->assertCount(2, $services);
-        $this->assertArrayHasKey('foo', $services);
-        $this->assertArrayHasKey('bar', $services);
+        self::assertCount(2, $services);
+        self::assertArrayHasKey('foo', $services);
+        self::assertArrayHasKey('bar', $services);
     }
 
     /**
@@ -400,31 +400,31 @@ class SmdTest extends TestCase
         // ... : SMD service description requires a name; none provided
         $smdDestination->setOptions($smdSource->toArray());
 
-        $this->assertEquals(
+        self::assertEquals(
             $smdSource->getContentType(),
             $smdDestination->getContentType()
         );
-        $this->assertEquals(
+        self::assertEquals(
             $smdSource->getDescription(),
             $smdDestination->getDescription()
         );
-        $this->assertEquals(
+        self::assertEquals(
             $smdSource->getEnvelope(),
             $smdDestination->getEnvelope()
         );
-        $this->assertEquals(
+        self::assertEquals(
             $smdSource->getId(),
             $smdDestination->getId()
         );
-        $this->assertEquals(
+        self::assertEquals(
             $smdSource->getTarget(),
             $smdDestination->getTarget()
         );
-        $this->assertEquals(
+        self::assertEquals(
             $smdSource->getTransport(),
             $smdDestination->getTransport()
         );
-        $this->assertEquals(
+        self::assertEquals(
             $smdSource->getServices(),
             $smdDestination->getServices()
         );

--- a/test/TestAsset/Bar.php
+++ b/test/TestAsset/Bar.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use Exception;
 
+// phpcs:disable
 class Bar
 {
     protected $val;
@@ -28,8 +31,6 @@ class Bar
 
     /**
      * Baz
-     *
-     * @return void
      */
     public function baz(): void
     {

--- a/test/TestAsset/Foo.php
+++ b/test/TestAsset/Foo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use Exception;
@@ -24,8 +26,6 @@ class Foo
 
     /**
      * Baz
-     *
-     * @return void
      */
     public function baz(): void
     {

--- a/test/TestAsset/FooFunc.php
+++ b/test/TestAsset/FooFunc.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 /**
  * Test function for JSON-RPC server
- *
- * @return bool
  */
 function FooFunc(): bool
 {

--- a/test/TestAsset/FooParameters.php
+++ b/test/TestAsset/FooParameters.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 /**

--- a/test/TestAsset/JsonSerializableBuiltinImpl.php
+++ b/test/TestAsset/JsonSerializableBuiltinImpl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use JsonSerializable;

--- a/test/TestAsset/JsonSerializableLaminasImpl.php
+++ b/test/TestAsset/JsonSerializableLaminasImpl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use Laminas\Stdlib\JsonSerializable;

--- a/test/TestAsset/TestIteratorAggregate.php
+++ b/test/TestAsset/TestIteratorAggregate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Json\Server\TestAsset;
 
 use ArrayIterator;
@@ -10,7 +12,7 @@ use IteratorAggregate;
  */
 class TestIteratorAggregate implements IteratorAggregate
 {
-    protected $array = [
+    protected array $array = [
         'foo' => 'bar',
         'baz' => 5,
     ];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Drops support for PHP versions prior to 7.4
- Adds support for PHP version 8.1
- Upgrades
  - `laminas/laminas-coding-standard` from `1.0.0` to latest `2.3.0`
  - `phpunit/phpunit` to latest `9.5.13`
  - `vimeo/psalm` to latest `4.20.0`